### PR TITLE
feat: Add CodeUnderstandingTool and register with ToolDispatcher

### DIFF
--- a/configs/formula_configs/default_formulas.json
+++ b/configs/formula_configs/default_formulas.json
@@ -56,5 +56,19 @@
         "enabled": true,
         "version": "1.0",
         "response_template": null
+    },
+    {
+        "name": "list_tools_formula",
+        "conditions": ["list tools", "what tools do you have", "show available tools", "tool list"],
+        "action": "dispatch_tool",
+        "description": "Lists the available Python tools the AI can describe or use.",
+        "parameters": {
+            "tool_name": "inspect_code",
+            "tool_query": "list_tools"
+        },
+        "priority": 20,
+        "enabled": true,
+        "version": "1.0",
+        "response_template": null
     }
 ]

--- a/src/tools/code_understanding_tool.py
+++ b/src/tools/code_understanding_tool.py
@@ -1,0 +1,220 @@
+import os
+import json # For potentially pretty-printing dicts if needed, though aiming for formatted string.
+from typing import List, Optional, Union, Dict, Any
+
+from core_ai.code_understanding.lightweight_code_model import LightweightCodeModel
+
+class CodeUnderstandingTool:
+    """
+    A tool to inspect and understand the structure of other Python tools
+    within the project using LightweightCodeModel.
+    """
+
+    def __init__(self, tools_directory: str = "src/tools/"):
+        """
+        Initializes the CodeUnderstandingTool.
+
+        Args:
+            tools_directory (str): The root directory where tool files are located.
+                                   This is passed to the LightweightCodeModel.
+        """
+        self.code_model = LightweightCodeModel(tools_directory=tools_directory)
+        self.tools_directory = tools_directory # Store for constructing full paths if needed by describe_tool
+
+    def list_tools(self) -> str:
+        """
+        Lists the names of available Python tools in the project.
+
+        Returns:
+            str: A message listing the tool names, or indicating if none are found.
+        """
+        tool_files = self.code_model.list_tool_files()
+        if not tool_files:
+            return "No Python tools found in the tools directory."
+
+        tool_names = []
+        for f_path in tool_files:
+            base_name = os.path.basename(f_path)
+            tool_name, _ = os.path.splitext(base_name)
+            tool_names.append(tool_name)
+
+        if not tool_names: # Should not happen if tool_files is not empty and files have names
+             return "No Python tools found after processing file list."
+
+        return f"Available Python tools: {', '.join(sorted(tool_names))}."
+
+    def describe_tool(self, tool_name: str) -> str:
+        """
+        Describes the structure of a specified Python tool.
+
+        Args:
+            tool_name (str): The name of the tool (e.g., "math_tool").
+
+        Returns:
+            str: A human-readable description of the tool's structure,
+                 or an error message if the tool is not found or cannot be analyzed.
+        """
+        # Construct the potential filepath. LightweightCodeModel's get_tool_structure
+        # also does this, but we do it here to provide a clearer path to it.
+        # Tool names are expected without .py extension.
+
+        # LightweightCodeModel.get_tool_structure can handle name or path.
+        # We pass the name, and it will try to resolve it.
+        structure = self.code_model.get_tool_structure(tool_name)
+
+        if not structure:
+            return f"Tool '{tool_name}' not found or could not be analyzed."
+
+        # Format the structure into a human-readable string
+        description_parts = []
+
+        filepath = structure.get("filepath", tool_name)
+        description_parts.append(f"Description for tool '{tool_name}' (from {os.path.basename(filepath)}):")
+
+        if not structure.get("classes") and not structure.get("functions"):
+            description_parts.append("  No classes or functions found in this tool file.")
+            return "\n".join(description_parts)
+
+        for class_info in structure.get("classes", []):
+            description_parts.append(f"\n  Class: {class_info.get('name', 'Unnamed Class')}")
+            class_doc = class_info.get('docstring')
+            if class_doc:
+                description_parts.append(f"    Docstring: {class_doc.strip()}")
+
+            if not class_info.get("methods"):
+                description_parts.append("    (No methods found in this class)")
+                continue
+
+            description_parts.append("    Methods:")
+            for method_info in class_info.get("methods", []):
+                method_name = method_info.get('name', 'unnamed_method')
+                param_list = []
+                for p in method_info.get("parameters", []):
+                    p_str = p.get('name', '')
+                    if p.get('annotation'):
+                        p_str += f": {p['annotation']}"
+                    if p.get('default') is not None: # Important: default can be None or a string "None"
+                        p_str += f" = {p['default']}"
+                    param_list.append(p_str)
+                params_str = ", ".join(param_list)
+
+                return_str = ""
+                if method_info.get('returns'):
+                    return_str = f" -> {method_info['returns']}"
+
+                description_parts.append(f"      - {method_name}({params_str}){return_str}")
+                method_doc = method_info.get('docstring')
+                if method_doc:
+                    # Indent docstring lines for readability
+                    indented_doc = "\n".join([f"        {line.strip()}" for line in method_doc.strip().splitlines()])
+                    description_parts.append(f"        Docstring:\n{indented_doc}")
+
+        for func_info in structure.get("functions", []): # Module-level functions
+            description_parts.append(f"\n  Function: {func_info.get('name', 'Unnamed Function')}")
+            func_doc = func_info.get('docstring')
+            if func_doc:
+                description_parts.append(f"    Docstring: {func_doc.strip()}")
+
+            param_list = []
+            for p in func_info.get("parameters", []):
+                p_str = p.get('name', '')
+                if p.get('annotation'):
+                    p_str += f": {p['annotation']}"
+                if p.get('default') is not None:
+                    p_str += f" = {p['default']}"
+                param_list.append(p_str)
+            params_str = ", ".join(param_list)
+
+            return_str = ""
+            if func_info.get('returns'):
+                return_str = f" -> {func_info['returns']}"
+
+            description_parts.append(f"    Signature: {func_info.get('name', 'unnamed_function')}({params_str}){return_str}")
+
+        return "\n".join(description_parts)
+
+    def execute(self, action: str, tool_name: Optional[str] = None) -> str:
+        """
+        Main execution entry point for the tool.
+        Routes to specific methods based on action.
+        """
+        if action == "list_tools":
+            return self.list_tools()
+        elif action == "describe_tool":
+            if not tool_name:
+                return "Error: 'tool_name' parameter is required for the 'describe_tool' action."
+            return self.describe_tool(tool_name)
+        else:
+            return f"Error: Unknown action '{action}' for CodeUnderstandingTool. Available actions: list_tools, describe_tool."
+
+if __name__ == '__main__':
+    # Example Usage (for testing during development)
+    # This assumes the script is run from the project root or PYTHONPATH is set.
+
+    # For this to work, LightweightCodeModel needs to find actual tool files.
+    # Ensure src/tools contains some .py files like math_tool.py, etc.
+    # Example: Create a dummy src/tools/dummy_example_tool.py
+
+    # Create dummy tool directory and file for testing if they don't exist
+    dummy_tools_path = "src/tools" # Default for LightweightCodeModel
+    if not os.path.exists(dummy_tools_path):
+        os.makedirs(dummy_tools_path)
+        print(f"Created dummy directory: {dummy_tools_path}")
+
+    dummy_tool_content = """
+class MyDummyTool:
+    \"\"\"This is a dummy tool for testing.\"\"\"
+    def __init__(self):
+        pass
+    def run(self, input_val: str) -> str:
+        \"\"\"Runs the dummy tool.\"\"\"
+        return f"Processed: {input_val}"
+"""
+    dummy_tool_filepath = os.path.join(dummy_tools_path, "dummy_example_tool.py")
+    if not os.path.exists(dummy_tool_filepath):
+        with open(dummy_tool_filepath, "w") as f:
+            f.write(dummy_tool_content)
+        print(f"Created dummy tool file: {dummy_tool_filepath}")
+
+    # Test with a specific path to the tools directory if needed, e.g. if running this file directly
+    # from its own location and `src/tools` is not found relative to CWD.
+    # For now, relying on default path or that script is run from project root.
+    tool_inspector = CodeUnderstandingTool()
+
+    print("--- Testing list_tools ---")
+    tool_list_output = tool_inspector.execute("list_tools")
+    print(tool_list_output)
+
+    print("\n--- Testing describe_tool (for an existing tool, e.g., 'math_tool') ---")
+    # Assuming 'math_tool.py' exists in 'src/tools/'
+    # If not, this will show "not found" or an error if the path isn't right.
+    # For robust testing, use a known dummy tool or mock LightweightCodeModel.
+    # The dummy_example_tool.py created above should be found if pathing is right.
+
+    # Try describing the dummy tool first
+    desc_output_dummy = tool_inspector.execute("describe_tool", tool_name="dummy_example_tool")
+    print(desc_output_dummy)
+
+    # Try describing a potentially existing tool like 'math_tool'
+    # This relies on 'math_tool.py' being in the default 'src/tools/' directory
+    # and being parsable by LightweightCodeModel.
+    print("\n--- Testing describe_tool (for 'math_tool', assuming it exists) ---")
+    desc_output_math = tool_inspector.execute("describe_tool", tool_name="math_tool")
+    print(desc_output_math)
+
+    print("\n--- Testing describe_tool (for a non-existent tool) ---")
+    desc_output_non_existent = tool_inspector.execute("describe_tool", tool_name="non_existent_tool_xyz")
+    print(desc_output_non_existent)
+
+    # Clean up dummy tool file if created by this test script
+    if os.path.exists(dummy_tool_filepath) and "dummy_example_tool.py" in dummy_tool_filepath:
+         # Basic safety check on path before deleting
+        try:
+            # os.remove(dummy_tool_filepath)
+            # print(f"Cleaned up dummy tool file: {dummy_tool_filepath}")
+            # For now, let's not auto-delete during typical runs, only if specifically for cleanup.
+            pass
+        except OSError as e:
+            print(f"Error deleting dummy tool file: {e}")
+
+    print("\nCodeUnderstandingTool example usage finished.")

--- a/tests/tools/test_code_understanding_tool.py
+++ b/tests/tools/test_code_understanding_tool.py
@@ -1,0 +1,122 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+
+# Assuming src is in PYTHONPATH for test execution
+from tools.code_understanding_tool import CodeUnderstandingTool
+from core_ai.code_understanding.lightweight_code_model import LightweightCodeModel # Added import
+
+class TestCodeUnderstandingTool(unittest.TestCase):
+
+    def setUp(self):
+        # Create a mock instance for LightweightCodeModel
+        self.mock_lwm_instance = MagicMock(spec=LightweightCodeModel)
+
+        # Patch the LightweightCodeModel class specifically where it's imported by CodeUnderstandingTool
+        self.lwm_patcher = patch('tools.code_understanding_tool.LightweightCodeModel', return_value=self.mock_lwm_instance)
+        # Start the patcher and keep a reference to the Mock Class if needed, though instance is usually enough
+        self.MockLWMClass = self.lwm_patcher.start()
+        self.addCleanup(self.lwm_patcher.stop) # Ensure patch is stopped after test method
+
+        # Instantiate the tool, which will now use self.mock_lwm_instance
+        self.tool = CodeUnderstandingTool(tools_directory="dummy/tools")
+
+    def test_list_tools_success(self):
+        # Configure the mock_lwm_instance (which is self.tool.code_model)
+        mock_tool_files = [
+            os.path.join("dummy/tools", "math_tool.py"), # Note: self.tool.tools_directory is not used by mock
+            os.path.join("dummy/tools", "another_tool.py"),
+            os.path.join("dummy/tools", "subdir", "sub_tool.py")
+        ]
+        self.mock_lwm_instance.list_tool_files.return_value = mock_tool_files
+
+        expected_output = "Available Python tools: another_tool, math_tool, sub_tool."
+        result = self.tool.execute("list_tools")
+
+        self.assertEqual(result, expected_output)
+        self.mock_lwm_instance.list_tool_files.assert_called_once()
+
+    def test_list_tools_no_tools_found(self):
+        self.mock_lwm_instance.list_tool_files.return_value = []
+
+        expected_output = "No Python tools found in the tools directory."
+        result = self.tool.execute("list_tools")
+
+        self.assertEqual(result, expected_output)
+
+    def test_describe_tool_found(self): # Removed @patch('os.path.isfile')
+        tool_name = "math_tool"
+
+        mock_structure = {
+            "filepath": f"dummy/tools/{tool_name}.py",
+            "classes": [
+                {
+                    "name": "MathTool",
+                    "docstring": "Performs math.",
+                    "methods": [
+                        {
+                            "name": "execute",
+                            "docstring": "Runs calculation.",
+                            "parameters": [
+                                {"name": "self", "annotation": None, "default": None},
+                                {"name": "expr", "annotation": "str", "default": None}
+                            ],
+                            "returns": "float"
+                        }
+                    ]
+                }
+            ],
+            "functions": []
+        }
+        self.mock_lwm_instance.get_tool_structure.return_value = mock_structure
+
+        result = self.tool.execute("describe_tool", tool_name=tool_name)
+
+        self.assertIn(f"Description for tool '{tool_name}'", result)
+        self.assertIn("Class: MathTool", result)
+        self.assertIn("Docstring: Performs math.", result)
+        self.assertIn("Methods:", result)
+        self.assertIn("- execute(self, expr: str) -> float", result) # Check formatting
+        self.assertIn("Docstring:\n        Runs calculation.", result)
+        self.mock_lwm_instance.get_tool_structure.assert_called_once_with(tool_name)
+
+    def test_describe_tool_structure_with_no_docstrings_or_params(self): # Removed @patch
+        tool_name = "minimal_tool"
+        mock_structure = {
+            "filepath": f"dummy/tools/{tool_name}.py",
+            "classes": [{"name": "MinimalTool", "docstring": None, "methods": [
+                {"name": "run", "docstring": None, "parameters": [], "returns": None}
+            ]}],
+            "functions": []
+        }
+        self.mock_lwm_instance.get_tool_structure.return_value = mock_structure
+        result = self.tool.execute("describe_tool", tool_name=tool_name)
+        self.assertIn("Class: MinimalTool", result)
+        self.assertNotIn("Docstring:", result.split("Class: MinimalTool")[1].split("Methods:")[0]) # No class docstring
+        self.assertIn("- run()", result) # Empty params
+        self.assertNotIn("->", result.split("- run()")[1].split("\n")[0]) # No return type
+        self.assertNotIn("Docstring:", result.split("- run()")[1]) # No method docstring
+
+    def test_describe_tool_not_found(self):
+        tool_name = "unknown_tool"
+        self.mock_lwm_instance.get_tool_structure.return_value = None # LWM returns None if not found
+
+        expected_output = f"Tool '{tool_name}' not found or could not be analyzed."
+        result = self.tool.execute("describe_tool", tool_name=tool_name)
+
+        self.assertEqual(result, expected_output)
+        self.mock_lwm_instance.get_tool_structure.assert_called_once_with(tool_name)
+
+    def test_execute_unknown_action(self):
+        action = "non_existent_action"
+        expected_output = f"Error: Unknown action '{action}' for CodeUnderstandingTool. Available actions: list_tools, describe_tool."
+        result = self.tool.execute(action)
+        self.assertEqual(result, expected_output)
+
+    def test_execute_describe_tool_missing_tool_name(self):
+        expected_output = "Error: 'tool_name' parameter is required for the 'describe_tool' action."
+        result = self.tool.execute("describe_tool") # tool_name is None
+        self.assertEqual(result, expected_output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Implements CodeUnderstandingTool in src/tools/ to provide information about other Python tools using LightweightCodeModel.
  - 'list_tools' action: Lists available tool names.
  - 'describe_tool' action: Provides a formatted string describing a tool's classes, methods, docstrings, parameters, and return types.
- Modifies ToolDispatcher to register and use CodeUnderstandingTool via an 'inspect_code' tool name and a new _execute_code_inspection method.
- Adds unit tests for CodeUnderstandingTool, mocking LightweightCodeModel.
- (Stretch Goal) Adds 'list_tools_formula' to default_formulas.json to trigger the new tool for listing tools.