### PR TITLE
feat: Implement initial HSP framework and integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,6 @@ spacy
 
 # For graph creation and manipulation
 networkx
+
+# For HSPConnector MQTT transport
+paho-mqtt

--- a/scripts/mock_hsp_peer.py
+++ b/scripts/mock_hsp_peer.py
@@ -1,0 +1,225 @@
+# scripts/mock_hsp_peer.py
+import asyncio
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+
+# We need to ensure that 'src' is in PYTHONPATH if running this script directly
+# This adds the project root to sys.path
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.hsp.connector import HSPConnector
+from src.hsp.types import HSPMessageEnvelope, HSPFactPayload #, HSPTaskRequestPayload, HSPTaskResultPayload # Add more as needed
+
+# Define other payload types that might be used by the mock, even if just for type hinting
+from src.hsp.types import HSPTaskRequestPayload, HSPTaskResultPayload, HSPEnvironmentalStatePayload
+
+
+class MockHSPPeer:
+    def __init__(self, ai_id: str, broker_address: str, broker_port: int = 1883):
+        self.ai_id = ai_id
+        self.connector = HSPConnector(
+            ai_id=self.ai_id,
+            broker_address=broker_address,
+            broker_port=broker_port,
+            client_id_suffix="mock_peer" # Unique suffix for MQTT client ID
+        )
+        self.connector.register_on_generic_message_callback(self.handle_generic_hsp_message)
+        self.connector.register_on_fact_callback(self.handle_fact_message)
+        # self.connector.register_on_task_request_callback(self.handle_task_request_message) # Example for future
+
+    def handle_generic_hsp_message(self, envelope: HSPMessageEnvelope, topic: str) -> None:
+        print(f"\n[MockPeer-{self.ai_id}] Received generic HSP message on MQTT topic '{topic}':")
+        print(f"  Msg ID  : {envelope.get('message_id')}")
+        print(f"  Sender  : {envelope.get('sender_ai_id')}")
+        print(f"  Type    : {envelope.get('message_type')}")
+        # Avoid printing large payloads in generic handler unless debugging
+        # print(f"  Payload: {json.dumps(envelope.get('payload'), indent=2)}")
+
+    def handle_fact_message(self, fact_payload: HSPFactPayload, sender_ai_id: str, full_envelope: HSPMessageEnvelope) -> None:
+        print(f"\n[MockPeer-{self.ai_id}] Received FACT from '{sender_ai_id}' (MQTT topic: '{full_envelope.get('recipient_ai_id')}'):")
+        statement_nl = fact_payload.get('statement_nl', 'N/A')
+        statement_structured = fact_payload.get('statement_structured', {})
+        statement_to_print = statement_nl if statement_nl != 'N/A' else statement_structured
+
+        print(f"  Fact ID    : {fact_payload.get('id')}")
+        print(f"  Statement  : {statement_to_print}")
+        print(f"  Confidence : {fact_payload.get('confidence_score')}")
+
+    # Example for handling task requests - would require HSPConnector to have a specific callback registration for this
+    # def handle_task_request_message(self, task_payload: HSPTaskRequestPayload, sender_id: str, envelope: HSPMessageEnvelope):
+    #     print(f"\n[MockPeer-{self.ai_id}] Received TASK REQUEST from {sender_id}")
+    #     capability_requested = task_payload.get('capability_id_filter') or task_payload.get('capability_name_filter')
+    #     print(f"  Capability: {capability_requested}")
+    #     print(f"  Parameters: {task_payload.get('parameters')}")
+    #     # Mock sending a result
+    #     if capability_requested == "mock_echo_v1" and envelope.get('correlation_id'):
+    #         result_payload = HSPTaskResultPayload(
+    #             result_id=f"taskres_{uuid.uuid4().hex}",
+    #             request_id=task_payload['request_id'], # type: ignore # request_id is required
+    #             executing_ai_id=self.ai_id,
+    #             status="success",
+    #             payload={"echoed_data": task_payload.get('parameters')},
+    #             timestamp_completed=datetime.now(timezone.utc).isoformat()
+    #         )
+    #         # The connector would need a method like send_response or send_task_result
+    #         # self.connector.send_hsp_response(result_payload, "HSP::TaskResult_v0.1", envelope['sender_ai_id'], envelope['correlation_id'])
+    #         print(f"  MockPeer: Would send TaskResult for request {task_payload.get('request_id')}")
+
+
+    async def run_loop(self):
+        """Main loop for the mock peer to publish sample data periodically."""
+        fact_counter = 0
+        env_counter = 0
+        while self.connector.is_connected:
+            await asyncio.sleep(15) # Action every 15 seconds
+
+            # Alternate between publishing a fact and an environmental state
+            if fact_counter <= env_counter:
+                fact_counter += 1
+                print(f"\n[MockPeer-{self.ai_id}] Periodic action: Publishing sample fact {fact_counter}...")
+                self.publish_sample_fact(fact_counter)
+            else:
+                env_counter += 1
+                print(f"\n[MockPeer-{self.ai_id}] Periodic action: Publishing sample environment state {env_counter}...")
+                self.publish_sample_environmental_state(env_counter)
+
+
+    def publish_sample_fact(self, counter: int):
+        if not self.connector.is_connected:
+            return
+
+        fact_id = f"mock_fact_{self.ai_id.replace(':', '_')}_{counter}_{uuid.uuid4().hex[:4]}"
+        timestamp = datetime.now(timezone.utc).isoformat()
+        topic = "hsp/knowledge/facts/general"
+
+        if counter % 2 == 0: # Publish a structured fact (semantic triple)
+            fact_payload = HSPFactPayload(
+                id=fact_id,
+                statement_type="semantic_triple",
+                statement_structured={ # type: ignore
+                    "subject_uri": f"hsp:entity:mock_subject_{counter}",
+                    "predicate_uri": "hsp:property:has_status",
+                    "object_literal": f"active_state_{counter}",
+                    "object_datatype": "xsd:string"
+                },
+                statement_nl=f"Mock subject {counter} has status active_state_{counter}.", # Optional NL representation
+                source_ai_id=self.ai_id,
+                timestamp_created=timestamp,
+                confidence_score=0.98,
+                tags=["sample_mock_fact", "structured_triple"]
+            )
+            print(f"[MockPeer-{self.ai_id}] Publishing STRUCTURED sample fact to '{topic}' (ID: {fact_payload['id']})")
+        else: # Publish a natural language fact
+            fact_payload = HSPFactPayload(
+                id=fact_id,
+                statement_type="natural_language",
+                statement_nl=f"This is sample natural language fact number {counter} from {self.ai_id} about a random event.",
+                source_ai_id=self.ai_id,
+                timestamp_created=timestamp,
+                confidence_score=0.92,
+                tags=["sample_mock_fact", "natural_language"]
+            )
+            print(f"[MockPeer-{self.ai_id}] Publishing NL sample fact to '{topic}' (ID: {fact_payload['id']})")
+
+        self.connector.publish_fact(fact_payload, topic=topic)
+
+
+    def publish_sample_environmental_state(self, counter: int):
+        """Example of the mock peer publishing something."""
+        if not self.connector.is_connected:
+            return
+
+        payload = HSPEnvironmentalStatePayload( # type: ignore # TypedDict should be fine
+            update_id=f"env_update_{uuid.uuid4().hex[:6]}",
+            source_ai_id=self.ai_id, # This AI is the source
+            phenomenon_type="hsp:event:MockPeerHeartbeat",
+            parameters={"count": counter, "status": "alive", "peer_id": self.ai_id},
+            timestamp_observed=datetime.now(timezone.utc).isoformat(),
+            scope_type="global"
+        )
+        topic = "hsp/environment/peer_updates" # CLI peer doesn't subscribe to this by default
+        print(f"[MockPeer-{self.ai_id}] Publishing sample environmental state to '{topic}' (ID: {payload['update_id']})")
+
+        envelope = self.connector._build_hsp_envelope(
+            payload=payload,
+            message_type="HSP::EnvironmentalState_v0.1",
+            recipient_ai_id_or_topic=topic,
+            communication_pattern="publish"
+        )
+        self.connector._send_hsp_message(envelope, mqtt_topic=topic)
+
+
+    async def start(self):
+        print(f"[MockPeer-{self.ai_id}] Attempting to connect...")
+        if self.connector.connect(): # This starts the MQTT client's own network loop thread
+            # Wait briefly for the on_connect callback to fire and set self.connector.is_connected
+            await asyncio.sleep(1)
+
+            if self.connector.is_connected:
+                print(f"[MockPeer-{self.ai_id}] Successfully connected to MQTT broker.")
+                # Subscribe to topics of interest
+                self.connector.subscribe("hsp/knowledge/facts/#") # All facts
+                self.connector.subscribe(f"hsp/requests/{self.ai_id}/#") # Task requests for this mock AI (example)
+                self.connector.subscribe("hsp/knowledge/facts/user_statements") # From LearningManager
+                self.connector.subscribe("hsp/knowledge/facts/user_preferences") # From LearningManager
+                self.connector.subscribe("hsp/knowledge/facts/general") # From LearningManager default
+
+                print(f"[MockPeer-{self.ai_id}] Subscribed to relevant topics. Listening...")
+
+                # Start a task for periodic publishing
+                asyncio.create_task(self.run_loop())
+
+                # Keep the main start task alive to listen (or until KeyboardInterrupt)
+                # The actual listening happens in the MQTT client's thread.
+                # This loop is just to keep the script running.
+                while True:
+                    await asyncio.sleep(1)
+            else:
+                print(f"[MockPeer-{self.ai_id}] Failed to establish connection after connect() call.")
+        else:
+            print(f"[MockPeer-{self.ai_id}] Initial MqttClient.connect() call failed or did not initiate connection.")
+
+    def stop(self):
+        print(f"[MockPeer-{self.ai_id}] Stopping...")
+        self.connector.disconnect()
+        print(f"[MockPeer-{self.ai_id}] Disconnected.")
+
+
+async def main_async_runner():
+    peer_id = f"did:hsp:mock_peer_{uuid.uuid4().hex[:8]}"
+    print(f"--- Starting Mock HSP Peer --- \nID: {peer_id}")
+    # Ensure MQTT broker is running at localhost:1883
+    peer = MockHSPPeer(ai_id=peer_id, broker_address="localhost", broker_port=1883)
+
+    try:
+        await peer.start()
+    except KeyboardInterrupt:
+        print(f"\n[MockPeer-{peer_id}] KeyboardInterrupt received.")
+    except Exception as e:
+        print(f"[MockPeer-{peer_id}] An error occurred: {e}")
+    finally:
+        print(f"[MockPeer-{peer_id}] Shutting down...")
+        peer.stop()
+        # Allow time for MQTT disconnect to complete
+        await asyncio.sleep(1)
+        print(f"[MockPeer-{peer_id}] Exited.")
+
+if __name__ == "__main__":
+    # To run this:
+    # 1. Ensure MQTT broker is running (e.g., `docker run -it -p 1883:1883 -p 9001:9001 eclipse-mosquitto`)
+    # 2. Run this script: python scripts/mock_hsp_peer.py
+    # 3. Separately, run your main AI application which also connects to HSP and publishes.
+
+    # Add a simple check for paho-mqtt
+    try:
+        import paho.mqtt.client
+    except ImportError:
+        print("Error: paho-mqtt library not found. Please install it: pip install paho-mqtt")
+        sys.exit(1)
+
+    asyncio.run(main_async_runner())
+```

--- a/src/core_ai/learning/learning_manager.py
+++ b/src/core_ai/learning/learning_manager.py
@@ -2,28 +2,40 @@ import uuid
 from datetime import datetime
 from typing import Optional, List, Dict, Any
 
-# Assuming 'src' is in PYTHONPATH, making 'core_ai' and 'shared' top-level packages
+import json # Added for json.dumps in process_and_store_hsp_fact
+# Assuming 'src' is in PYTHONPATH, making 'core_ai', 'shared', and 'hsp' top-level packages
 from core_ai.memory.ham_memory_manager import HAMMemoryManager
 from core_ai.learning.fact_extractor_module import FactExtractorModule
+from core_ai.learning.content_analyzer_module import ContentAnalyzerModule # Import ContentAnalyzerModule
 from shared.types.common_types import LearnedFactRecord
+from hsp.connector import HSPConnector # Import HSPConnector
+from hsp.types import HSPFactPayload, HSPMessageEnvelope # Ensure HSPMessageEnvelope is imported
 
 
 class LearningManager:
     def __init__(self,
+                 ai_id: str,
                  ham_memory_manager: HAMMemoryManager,
                  fact_extractor: FactExtractorModule,
+                 content_analyzer: Optional[ContentAnalyzerModule] = None, # Added content_analyzer
+                 hsp_connector: Optional[HSPConnector] = None,
                  operational_config: Optional[Dict[str, Any]] = None):
+        self.ai_id = ai_id
         self.ham_memory = ham_memory_manager
         self.fact_extractor = fact_extractor
+        self.content_analyzer = content_analyzer # Store ContentAnalyzerModule instance
+        self.hsp_connector = hsp_connector
         self.operational_config = operational_config or {}
 
         # Get thresholds from operational_config, with defaults
         learning_thresholds_config = self.operational_config.get("learning_thresholds", {})
         self.min_fact_confidence_to_store = learning_thresholds_config.get("min_fact_confidence_to_store", 0.7)
+        self.min_fact_confidence_to_share_via_hsp = learning_thresholds_config.get("min_fact_confidence_to_share_via_hsp", 0.8) # New threshold
+        self.default_hsp_fact_topic = self.operational_config.get("default_hsp_fact_topic", "hsp/knowledge/facts/general")
 
-        print(f"LearningManager initialized. Min fact confidence to store: {self.min_fact_confidence_to_store}")
+        print(f"LearningManager initialized for AI ID '{self.ai_id}'. Min fact confidence to store: {self.min_fact_confidence_to_store}, to share: {self.min_fact_confidence_to_share_via_hsp}")
 
-    async def process_and_store_learnables( # Made async
+    def process_and_store_learnables( # Kept synchronous for now to match HSPConnector
         self,
         text: str,
         user_id: Optional[str],
@@ -100,11 +112,158 @@ class LearningManager:
 
             if stored_id:
                 stored_fact_ids.append(stored_id)
-                print(f"LearningManager: Stored fact '{record_id}' with HAM ID '{stored_id}'")
+                print(f"LearningManager: Stored fact '{record_id}' (HAM ID '{stored_id}')")
+
+                # Now, potentially share this fact via HSP
+                if self.hsp_connector and confidence >= self.min_fact_confidence_to_share_via_hsp:
+                    hsp_fact_id = f"hspfact_{uuid.uuid4().hex}"
+
+                    # Determine statement_type and structured content for HSP
+                    # For now, let's assume fact_data["content"] is good for statement_structured
+                    # and fact_data["fact_type"] can inform statement_type or tags.
+                    # A more robust mapping might be needed.
+                    # If content is simple key-value, it might not directly map to semantic_triple without more processing.
+                    # Let's default to using content as a generic structured object for now.
+
+                    # For statement_nl, we could use the original text, or a summary if available.
+                    # For this PoC, let's use a part of the original source_text if available.
+                    nl_statement_for_hsp = source_text if source_text else "Fact content: " + str(content)
+
+
+                    hsp_payload = HSPFactPayload(
+                        id=hsp_fact_id,
+                        statement_type="natural_language", # Or determine from fact_type; default for PoC
+                        statement_nl=nl_statement_for_hsp, # Could be original snippet or generated summary
+                        statement_structured=content, # Use the 'content' from FactExtractor
+                        source_ai_id=self.ai_id, # This AI instance is the source for HSP
+                        original_source_info={ # type: ignore
+                            "type": "user_utterance",
+                            "identifier": user_id if user_id else "unknown_user",
+                            "context_refs": {"session_id": session_id, "interaction_ref": source_interaction_ref}
+                        },
+                        timestamp_created=timestamp, # Use the same timestamp as LearnedFactRecord
+                        timestamp_observed=timestamp, # Assuming creation and observation are close for user facts
+                        confidence_score=confidence,
+                        weight=1.0, # Default weight
+                        tags=[fact_type] if fact_type else ["user_derived"]
+                        # Other fields like valid_from/until, context, access_policy_id can be added
+                    )
+
+                    topic_to_publish = self.default_hsp_fact_topic
+                    # Potentially choose topic based on fact_type or content
+                    if "user_preference" in fact_type:
+                        topic_to_publish = "hsp/knowledge/facts/user_preferences"
+                    elif "user_statement" in fact_type:
+                        topic_to_publish = "hsp/knowledge/facts/user_statements"
+
+                    print(f"LearningManager: Publishing fact {hsp_fact_id} to HSP topic '{topic_to_publish}'")
+                    self.hsp_connector.publish_fact(hsp_payload, topic=topic_to_publish)
             else:
                 print(f"LearningManager: Failed to store fact '{record_id}' in HAM.")
 
         return stored_fact_ids
+
+    def process_and_store_hsp_fact(
+        self,
+        hsp_fact_payload: HSPFactPayload,
+        hsp_sender_ai_id: str,
+        hsp_envelope: HSPMessageEnvelope # For context, like original message_id
+    ) -> Optional[str]:
+        """
+        Processes a fact received via HSP and stores it in HAM if deemed appropriate.
+        """
+        print(f"LearningManager (AI ID: {self.ai_id}): Received HSP fact '{hsp_fact_payload.get('id')}' from '{hsp_sender_ai_id}'.")
+
+        # Basic validation and trust (very rudimentary for PoC)
+        # In a real system, hsp_sender_ai_id would be checked against a trust list/score.
+        confidence = hsp_fact_payload.get('confidence_score', 0.0)
+        if not isinstance(confidence, (float, int)): # Ensure confidence is a number
+            try:
+                confidence = float(confidence)
+            except (ValueError, TypeError):
+                print(f"LearningManager: Invalid confidence format in HSP fact: {confidence}. Defaulting to 0.0.")
+                confidence = 0.0
+
+        # Use a specific threshold for storing facts from HSP, could be different from user-derived facts.
+        # For now, let's use the existing min_fact_confidence_to_store or a dedicated one if configured.
+        min_confidence_for_hsp_fact = self.operational_config.get("learning_thresholds", {}).get("min_hsp_fact_confidence_to_store", self.min_fact_confidence_to_store)
+
+        if confidence < min_confidence_for_hsp_fact:
+            print(f"LearningManager: HSP fact '{hsp_fact_payload.get('id')}' confidence {confidence} is below threshold {min_confidence_for_hsp_fact}. Not storing.")
+            return None
+
+        record_id = f"lfact_hsp_{uuid.uuid4().hex}" # Learned Fact from HSP ID
+        timestamp = datetime.now().isoformat()
+
+        # Derive LearnedFactRecord components from HSPFactPayload
+        # statement_nl or statement_structured will form the core content.
+        # For HAM, we need to decide what the 'raw_data' (content) is vs metadata.
+
+        fact_content_for_ham: Any
+        source_text_for_ham: str
+
+        if hsp_fact_payload.get('statement_structured'):
+            fact_content_for_ham = hsp_fact_payload['statement_structured']
+            source_text_for_ham = hsp_fact_payload.get('statement_nl', json.dumps(fact_content_for_ham)) # Use NL if available, else serialize structured
+        elif hsp_fact_payload.get('statement_nl'):
+            fact_content_for_ham = {"text": hsp_fact_payload['statement_nl']} # Wrap NL in a simple dict for content
+            source_text_for_ham = hsp_fact_payload['statement_nl']
+        else:
+            print(f"LearningManager: HSP fact '{hsp_fact_payload.get('id')}' has no statement_structured or statement_nl. Cannot process.")
+            return None
+
+        fact_type_from_hsp = "hsp_derived_fact" # Default
+        if hsp_fact_payload.get('tags') and len(hsp_fact_payload['tags']) > 0: # type: ignore
+            fact_type_from_hsp = hsp_fact_payload['tags'][0] # Use first tag as fact_type for simplicity # type: ignore
+
+        learned_record_metadata = {
+            "record_id": record_id,
+            "timestamp": timestamp,
+            "user_id": None, # Not directly from a user of this AI instance
+            "session_id": None, # Not directly from a session of this AI instance
+            "source_interaction_ref": hsp_envelope.get('message_id'), # Link to the HSP message
+            "fact_type": fact_type_from_hsp,
+            "confidence": confidence,
+            "source_text": source_text_for_ham, # The textual representation of the fact
+            "hsp_originator_ai_id": hsp_fact_payload.get('source_ai_id'), # The AI that originally created the fact
+            "hsp_sender_ai_id": hsp_sender_ai_id, # The AI that sent this HSP message
+            "hsp_fact_id": hsp_fact_payload.get('id') # Original ID of the fact from HSP network
+        }
+
+        ham_data_type = f"hsp_learned_fact_{fact_type_from_hsp.lower().replace(' ', '_')}"
+
+        print(f"LearningManager: Storing HSP-derived fact - Type: {ham_data_type}, Content: {fact_content_for_ham}, Meta: {learned_record_metadata}")
+
+        stored_id = self.ham_memory.store_experience(
+            raw_data=fact_content_for_ham,
+            data_type=ham_data_type,
+            metadata=learned_record_metadata
+        )
+
+        if stored_id:
+            print(f"LearningManager: Stored HSP fact '{record_id}' (original HSP ID: {hsp_fact_payload.get('id')}) with HAM ID '{stored_id}'")
+
+            # Now, if ContentAnalyzer is available, pass the fact content for deeper analysis / KG integration
+            if self.content_analyzer:
+                # We pass the original hsp_fact_payload as it contains statement_type, statement_nl, statement_structured
+                # and the source_ai_id (hsp_sender_ai_id) for context.
+                try:
+                    print(f"LearningManager: Passing HSP fact content (ID: {hsp_fact_payload.get('id')}) to ContentAnalyzerModule.")
+                    analysis_updated_graph = self.content_analyzer.process_hsp_fact_content(
+                        hsp_fact_payload=hsp_fact_payload, # type: ignore # TypedDict should be compatible
+                        source_ai_id=hsp_sender_ai_id
+                    )
+                    if analysis_updated_graph:
+                        print(f"LearningManager: ContentAnalyzerModule reported graph updates for HSP fact '{hsp_fact_payload.get('id')}'.")
+                    else:
+                        print(f"LearningManager: ContentAnalyzerModule did not report graph updates for HSP fact '{hsp_fact_payload.get('id')}'.")
+                except Exception as e:
+                    print(f"LearningManager: Error calling ContentAnalyzerModule for HSP fact '{hsp_fact_payload.get('id')}': {e}")
+            return stored_id
+        else:
+            print(f"LearningManager: Failed to store HSP fact '{record_id}' in HAM.")
+            return None
+
 
 if __name__ == '__main__':
     print("--- LearningManager Standalone Test ---")
@@ -161,10 +320,43 @@ if __name__ == '__main__':
     mock_ham = MockHAMMemoryManager()
     fact_extractor = FactExtractorModule(llm_interface=patched_llm_for_facts)
 
-    learning_manager = LearningManager(ham_memory_manager=mock_ham, fact_extractor=fact_extractor)
+    # Mock HSPConnector
+    class MockHSPConnector:
+        def __init__(self, ai_id: str, broker_address: str, broker_port: int):
+            self.ai_id = ai_id
+            self.broker_address = broker_address
+            self.broker_port = broker_port
+            self.published_facts: List[Dict[str, Any]] = []
+            print(f"MockHSPConnector initialized for AI ID '{ai_id}'")
+
+        def publish_fact(self, fact_payload: HSPFactPayload, topic: str) -> bool:
+            print(f"MockHSPConnector: 'publish_fact' called for topic '{topic}'. Payload: {fact_payload.get('id')}")
+            self.published_facts.append({"payload": fact_payload, "topic": topic})
+            return True
+
+        def connect(self) -> bool: return True # Mock connect
+        def disconnect(self): pass # Mock disconnect
+
+    mock_hsp_connector = MockHSPConnector(ai_id="test_ai_lm", broker_address="dummy", broker_port=1883)
+
+    # Update LearningManager instantiation
+    learning_manager_config = {
+        "learning_thresholds": {
+            "min_fact_confidence_to_store": 0.7,
+            "min_fact_confidence_to_share_via_hsp": 0.85 # Set a threshold for testing sharing
+        },
+        "default_hsp_fact_topic": "hsp/knowledge/facts/test_general"
+    }
+    learning_manager = LearningManager(
+        ai_id="test_ai_lm", # Provide an AI ID
+        ham_memory_manager=mock_ham,
+        fact_extractor=fact_extractor,
+        hsp_connector=mock_hsp_connector, # Pass the mock connector
+        operational_config=learning_manager_config
+    )
 
     test_inputs = [
-        ("My favorite color is green and I work as a baker.", "user123", "sessionABC", "mem_dialogue_001"),
+        ("My favorite color is green and I work as a baker.", "user123", "sessionABC", "mem_dialogue_001"), # Both facts should be shared (conf 0.95, 0.9)
         ("I like apples.", "user123", "sessionABC", "mem_dialogue_002"),
         ("The weather is nice today.", "user456", "sessionXYZ", "mem_dialogue_003") # Should extract no facts
     ]
@@ -194,5 +386,40 @@ if __name__ == '__main__':
     # This part of the test will depend on how the PatchedLLM handles this new input.
     # If it returns empty, this assertion might need adjustment or the patch needs more rules.
     # For now, we're mostly testing the flow.
+
+    print("\n--- Verifying HSP Publishing ---")
+    # Expected:
+    # 1st input: "My favorite color is green and I work as a baker."
+    #   - Fact 1 (color green, conf 0.95) -> should be shared (0.95 >= 0.85)
+    #   - Fact 2 (occupation baker, conf 0.9) -> should be shared (0.9 >= 0.85)
+    # 2nd input: "I like apples."
+    #   - Fact 3 (likes apples, conf 0.88) -> should be shared (0.88 >= 0.85)
+    # 3rd input: "The weather is nice today." -> no facts extracted, so none shared.
+
+    expected_shared_facts_count = 3
+    actual_shared_facts_count = len(mock_hsp_connector.published_facts)
+    print(f"Expected shared facts via HSP: {expected_shared_facts_count}")
+    print(f"Actual shared facts via HSP  : {actual_shared_facts_count}")
+
+    assert actual_shared_facts_count == expected_shared_facts_count, \
+        f"Test Failed: Expected {expected_shared_facts_count} facts to be shared via HSP, but got {actual_shared_facts_count}"
+
+    if actual_shared_facts_count > 0:
+        first_shared_fact = mock_hsp_connector.published_facts[0]
+        print(f"First shared fact payload ID: {first_shared_fact['payload'].get('id')}")
+        print(f"First shared fact topic: {first_shared_fact['topic']}")
+        assert first_shared_fact['payload']['source_ai_id'] == "test_ai_lm"
+        assert first_shared_fact['payload']['confidence_score'] >= learning_manager.min_fact_confidence_to_share_via_hsp
+
+        # Check topics for the first two (color and occupation)
+        # Assuming they are published in order of extraction by FactExtractor's mock
+        if actual_shared_facts_count >= 2:
+             # Fact 1 (color green, type user_preference)
+            assert mock_hsp_connector.published_facts[0]['topic'] == "hsp/knowledge/facts/user_preferences"
+            # Fact 2 (occupation baker, type user_statement)
+            assert mock_hsp_connector.published_facts[1]['topic'] == "hsp/knowledge/facts/user_statements"
+            # Fact 3 (likes apples, type user_preference)
+            assert mock_hsp_connector.published_facts[2]['topic'] == "hsp/knowledge/facts/user_preferences"
+
 
     print("\nLearningManager standalone test finished.")

--- a/src/hsp/__init__.py
+++ b/src/hsp/__init__.py
@@ -1,0 +1,2 @@
+# HSP Module
+# This module contains components related to the Heterogeneous Synchronization Protocol (HSP).

--- a/src/hsp/connector.py
+++ b/src/hsp/connector.py
@@ -1,0 +1,354 @@
+import json
+import uuid
+import asyncio
+from datetime import datetime, timezone
+from typing import Callable, Dict, Any, Optional, Literal # Added Optional, Literal, Dict, Any, Callable
+import paho.mqtt.client as mqtt # type: ignore # Using type: ignore as paho-mqtt might not have perfect type hints
+
+from .types import HSPMessageEnvelope, HSPFactPayload # Using .types for relative import
+
+# Placeholder for other payload types to be defined in src/hsp/types.py
+# e.g., HSPTaskRequestPayload, HSPTaskResultPayload etc.
+
+
+class HSPConnector:
+    """
+    Manages communication with the HSP network.
+    Handles message serialization/deserialization and transport interactions.
+    Initial version uses MQTT as the transport.
+    """
+    def __init__(self, ai_id: str, broker_address: str, broker_port: int = 1883, client_id_suffix: str = "hsp_connector"):
+        self.ai_id: str = ai_id
+        self.broker_address: str = broker_address
+        self.broker_port: int = broker_port
+        # Ensure client_id is unique if multiple instances run for the same AI, though typically one per AI.
+        self.mqtt_client_id: str = f"{self.ai_id}-{client_id_suffix}-{uuid.uuid4()}" # Unique client ID for MQTT
+
+        self.is_connected: bool = False
+        self.mqtt_client: mqtt.Client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=self.mqtt_client_id)
+        self.mqtt_client.on_connect = self._on_mqtt_connect
+        self.mqtt_client.on_disconnect = self._on_mqtt_disconnect
+        self.mqtt_client.on_message = self._on_mqtt_message
+
+        # Callbacks for different types of HSP messages
+        self._on_generic_message_callback = None # For any HSP message
+        self._on_fact_received_callback = None   # Specifically for HSP Fact payloads
+        # ... other specific payload callbacks can be added
+
+        self.default_qos: int = 1 # MQTT QoS level for publishing
+
+        # For managing subscriptions
+        self.subscribed_topics: set[str] = set()
+
+    def _on_mqtt_connect(self, client, userdata, flags, reason_code, properties):
+        if reason_code == 0:
+            print(f"HSPConnector ({self.ai_id}): Successfully connected to MQTT Broker at {self.broker_address}:{self.broker_port}")
+            self.is_connected = True
+            # Resubscribe to any topics if it's a reconnect
+            for topic in list(self.subscribed_topics): # Iterate over a copy
+                self.subscribe(topic)
+        else:
+            print(f"HSPConnector ({self.ai_id}): Failed to connect to MQTT Broker, reason code {reason_code}")
+            self.is_connected = False
+
+    def _on_mqtt_disconnect(self, client, userdata, reason_code, properties):
+        self.is_connected = False
+        print(f"HSPConnector ({self.ai_id}): Disconnected from MQTT Broker, reason code {reason_code}")
+        # TODO: Implement reconnection strategy
+
+    def _on_mqtt_message(self, client, userdata, msg):
+        """Handles incoming MQTT messages and forwards them to HSP message handler."""
+        print(f"HSPConnector ({self.ai_id}): Raw MQTT message received on topic '{msg.topic}'")
+        try:
+            message_str = msg.payload.decode('utf-8')
+            self._handle_hsp_message_str(message_str, msg.topic)
+        except Exception as e:
+            print(f"HSPConnector ({self.ai_id}): Error processing raw MQTT message: {e}")
+
+    def connect(self) -> bool:
+        """Connects to the MQTT broker."""
+        if self.is_connected:
+            print(f"HSPConnector ({self.ai_id}): Already connected.")
+            return True
+        try:
+            print(f"HSPConnector ({self.ai_id}): Attempting to connect to MQTT Broker at {self.broker_address}:{self.broker_port}...")
+            self.mqtt_client.connect(self.broker_address, self.broker_port, keepalive=60)
+            self.mqtt_client.loop_start() # Starts a background thread for network operations, callbacks
+            # Connection status will be updated by _on_mqtt_connect callback
+            # For initial check, we can assume it will connect or fail quickly for this simple version.
+            # A more robust version would await the on_connect callback.
+            # For now, we'll return True and let the callback update is_connected.
+            # This is a simplification for non-async paho-mqtt in an async conceptual flow.
+            return True
+        except Exception as e:
+            print(f"HSPConnector ({self.ai_id}): MQTT connection error: {e}")
+            self.is_connected = False
+            return False
+
+    def disconnect(self):
+        """Disconnects from the MQTT broker."""
+        if self.mqtt_client and self.is_connected:
+            self.mqtt_client.loop_stop()
+            self.mqtt_client.disconnect()
+            # is_connected will be set to False by _on_mqtt_disconnect
+        print(f"HSPConnector ({self.ai_id}): Disconnection process initiated.")
+
+    def _build_hsp_envelope(self, payload: Dict[str, Any], message_type: str, recipient_ai_id_or_topic: str,
+                            communication_pattern: Literal[
+                                "publish", "request", "response",
+                                "stream_data", "stream_ack",
+                                "acknowledgement", "negative_acknowledgement"
+                            ],
+                            correlation_id: Optional[str] = None,
+                            qos_params: Optional[HSPQoSParameters] = None,
+                            protocol_version: str = "0.1") -> HSPMessageEnvelope:
+        """Builds a standard HSP message envelope."""
+        effective_correlation_id = correlation_id if correlation_id else str(uuid.uuid4())
+
+        # Type casting to satisfy MyPy, though TypedDicts are structurally typed.
+        # This helps ensure all required fields are considered by the developer here.
+        envelope = HSPMessageEnvelope(
+            hsp_envelope_version="0.1",
+            message_id=str(uuid.uuid4()),
+            "correlation_id": effective_correlation_id,
+            "sender_ai_id": self.ai_id,
+            "recipient_ai_id": recipient_ai_id_or_topic, # Topic for publish, specific AI ID for request/response
+            "timestamp_sent": datetime.now(timezone.utc).isoformat(),
+            "message_type": message_type,
+            "protocol_version": protocol_version,
+            "communication_pattern": communication_pattern,
+            "security_parameters": {"signature_algorithm": None, "signature": None, "encryption_details": None}, # Basic for v0.1
+            "qos_parameters": qos_params if qos_params else {"priority": "medium", "requires_ack": False}, # HSP QoS, not MQTT QoS
+            "routing_info": {},
+            "payload_schema_uri": None, # TODO: Add schema URIs when defined
+            "payload": payload
+        )
+        return envelope
+
+    def _send_hsp_message(self, envelope: HSPMessageEnvelope, mqtt_topic: str, mqtt_qos: Optional[int] = None) -> bool:
+        """Sends a pre-built HSP envelope over MQTT."""
+        if not self.is_connected:
+            print(f"HSPConnector ({self.ai_id}): Not connected. Cannot send message.")
+            return False
+
+        message_str = json.dumps(envelope)
+        effective_mqtt_qos = mqtt_qos if mqtt_qos is not None else self.default_qos
+
+        try:
+            msg_info = self.mqtt_client.publish(mqtt_topic, payload=message_str, qos=effective_mqtt_qos)
+            msg_info.wait_for_publish(timeout=5) # Wait for publish confirmation (for QoS > 0)
+            if msg_info.is_published():
+                print(f"HSPConnector ({self.ai_id}): Successfully published message {envelope.get('message_id')} to topic '{mqtt_topic}' (MQTT MID: {msg_info.mid})")
+                return True
+            else:
+                print(f"HSPConnector ({self.ai_id}): Failed to publish message {envelope.get('message_id')} to topic '{mqtt_topic}' (MQTT MID: {msg_info.mid}) - not confirmed.")
+                return False
+        except Exception as e:
+            print(f"HSPConnector ({self.ai_id}): Error sending MQTT message to topic '{mqtt_topic}': {e}")
+            return False
+
+    def publish_fact(self, fact_payload: HSPFactPayload, topic: str, fact_payload_version: str = "0.1") -> bool:
+        """Publishes a Fact payload to a given HSP topic via MQTT."""
+        message_type = f"HSP::Fact_v{fact_payload_version}"
+        # TypedDict is structurally compatible with Dict[str, Any] for the payload argument
+        envelope = self._build_h_sp_envelope(
+            payload=fact_payload,
+            message_type=message_type,
+            recipient_ai_id_or_topic=topic, # For Pub/Sub, recipient_ai_id in envelope is the topic
+            communication_pattern="publish"
+        )
+        # For MQTT, the topic in the envelope is also the MQTT topic.
+        return self._send_hsp_message(envelope, mqtt_topic=topic)
+
+    def subscribe(self, topic: str, mqtt_qos: Optional[int] = None) -> bool:
+        """Subscribes to an MQTT topic to receive HSP messages."""
+        if not self.is_connected:
+            print(f"HSPConnector ({self.ai_id}): Not connected. Cannot subscribe to topic '{topic}'.")
+            return False
+        try:
+            effective_mqtt_qos = mqtt_qos if mqtt_qos is not None else self.default_qos
+            result, mid = self.mqtt_client.subscribe(topic, qos=effective_mqtt_qos)
+            if result == mqtt.MQTT_ERR_SUCCESS:
+                self.subscribed_topics.add(topic)
+                print(f"HSPConnector ({self.ai_id}): Successfully subscribed to topic '{topic}' with QoS {effective_mqtt_qos} (MID: {mid})")
+                return True
+            else:
+                print(f"HSPConnector ({self.ai_id}): Failed to subscribe to topic '{topic}', error code {result}")
+                return False
+        except Exception as e:
+            print(f"HSPConnector ({self.ai_id}): Error subscribing to topic '{topic}': {e}")
+            return False
+
+    def unsubscribe(self, topic: str) -> bool:
+        """Unsubscribes from an MQTT topic."""
+        if not self.is_connected:
+            print(f"HSPConnector ({self.ai_id}): Not connected. Cannot unsubscribe from topic '{topic}'.")
+            # Still remove from local tracking if desired
+            if topic in self.subscribed_topics:
+                self.subscribed_topics.remove(topic)
+            return False
+        try:
+            result, mid = self.mqtt_client.unsubscribe(topic)
+            if result == mqtt.MQTT_ERR_SUCCESS:
+                if topic in self.subscribed_topics:
+                    self.subscribed_topics.remove(topic)
+                print(f"HSPConnector ({self.ai_id}): Successfully unsubscribed from topic '{topic}' (MID: {mid})")
+                return True
+            else:
+                print(f"HSPConnector ({self.ai_id}): Failed to unsubscribe from topic '{topic}', error code {result}")
+                return False
+        except Exception as e:
+            print(f"HSPConnector ({self.ai_id}): Error unsubscribing from topic '{topic}': {e}")
+            return False
+
+    def _handle_hsp_message_str(self, message_str: str, received_on_topic: str):
+        """Deserializes and processes an incoming HSP message string."""
+        try:
+            envelope: HSPMessageEnvelope = json.loads(message_str)
+            # Basic validation of envelope structure (more robust with TypedDict/Pydantic)
+            if not all(k in envelope for k in ["message_id", "sender_ai_id", "message_type", "payload"]):
+                print(f"HSPConnector ({self.ai_id}): Received message with missing core envelope fields from topic '{received_on_topic}'.")
+                return
+
+            print(f"HSPConnector ({self.ai_id}): Decoded HSP message {envelope['message_id']} from {envelope['sender_ai_id']} on topic '{received_on_topic}'")
+
+            # Invoke generic callback if registered
+            if self._on_generic_message_callback:
+                try:
+                    self._on_generic_message_callback(envelope, received_on_topic)
+                except Exception as e:
+                    print(f"HSPConnector ({self.ai_id}): Error in generic message callback: {e}")
+
+            # Invoke specific callbacks based on message_type
+            payload = envelope.get("payload")
+            message_type = envelope.get("message_type")
+
+            if message_type and payload is not None: # Ensure payload is not None
+                if message_type.startswith("HSP::Fact") and self._on_fact_received_callback:
+                    try:
+                        # Pass payload, sender, and full envelope for context
+                        self._on_fact_received_callback(payload, envelope["sender_ai_id"], envelope)
+                    except Exception as e:
+                        print(f"HSPConnector ({self.ai_id}): Error in fact received callback: {e}")
+                # TODO: Add more specific handlers here for other message types (TaskRequest, etc.)
+
+            # TODO: Implement logic for sending ACKs if the received message's qos_parameters.requires_ack is true.
+            # This would involve crafting an HSP::Acknowledgement_v0.1 message and sending it back,
+            # likely to a reply-to topic or a direct topic for the sender_ai_id.
+
+        except json.JSONDecodeError:
+            print(f"HSPConnector ({self.ai_id}): Received invalid JSON on topic '{received_on_topic}': {message_str[:200]}...") # Log snippet
+        except Exception as e:
+            print(f"HSPConnector ({self.ai_id}): Unhandled error processing HSP message from topic '{received_on_topic}': {e}")
+
+from typing import Callable, Dict, Any, Optional, Literal # Ensure Literal is imported if not already
+
+# ... (rest of imports) ...
+
+# ... (class definition) ...
+
+    # Registration methods for callbacks
+    def register_on_generic_message_callback(self, callback: Callable[[HSPMessageEnvelope, str], None]):
+        """Registers a callback for all successfully decoded HSP messages.
+        Callback signature: func(envelope: HSPMessageEnvelope, received_on_topic: str) -> None
+        """
+        self._on_generic_message_callback = callback
+
+    def register_on_fact_callback(self, callback: Callable[[HSPFactPayload, str, HSPMessageEnvelope], None]):
+        """Registers a callback for HSP Fact messages.
+        Callback signature: func(fact_payload: HSPFactPayload, sender_ai_id: str, full_envelope: HSPMessageEnvelope) -> None
+        """
+        self._on_fact_received_callback = callback
+
+    def set_default_mqtt_qos(self, qos: int):
+        """Sets the default MQTT QoS level for publishing messages (0, 1, or 2)."""
+        if qos in [0, 1, 2]:
+            self.default_qos = qos
+        else:
+            print(f"HSPConnector ({self.ai_id}): Invalid MQTT QoS value {qos}. Must be 0, 1, or 2.")
+
+# Example of how this might be used (conceptual, would be in main application logic)
+async def example_hsp_usage():
+    print("Starting HSP Connector example...")
+    my_ai_id = "did:hsp:ai_example_123"
+    # Ensure an MQTT broker (like Mosquitto) is running at this address
+    connector = HSPConnector(ai_id=my_ai_id, broker_address="localhost", broker_port=1883)
+
+    # Define callback functions
+    def generic_hsp_message_handler(envelope: HSPMessageEnvelope, topic: str) -> None:
+        print(f"\n[Generic Handler] Received on topic '{topic}':")
+        print(f"  Message ID  : {envelope.get('message_id')}")
+        print(f"  Sender AI ID: {envelope.get('sender_ai_id')}")
+        print(f"  Message Type: {envelope.get('message_type')}")
+        print(f"  Payload     : {json.dumps(envelope.get('payload'), indent=2)}")
+
+    def fact_message_handler(fact_payload: HSPFactPayload, sender_id: str, envelope_context: HSPMessageEnvelope) -> None:
+        print(f"\n[Fact Handler] Fact from {sender_id}:")
+        # Accessing HSPFactPayload fields - ensuring they exist or using .get()
+        statement_nl = fact_payload.get('statement_nl')
+        statement_structured = fact_payload.get('statement_structured')
+        statement_to_print = statement_nl if statement_nl else statement_structured
+        print(f"  Statement: {statement_to_print}")
+        print(f"  Confidence: {fact_payload.get('confidence_score')}")
+        print(f"  Full Envelope Msg ID: {envelope_context.get('message_id')}")
+
+
+    connector.register_on_generic_message_callback(generic_hsp_message_handler)
+    connector.register_on_fact_callback(fact_message_handler)
+
+    if connector.connect(): # This starts the MQTT loop in a thread
+        print("Connector initiated connection sequence.")
+        # Wait a bit for connection to establish (in real app, use more robust check or awaitable connect)
+        await asyncio.sleep(2)
+
+        if connector.is_connected:
+            print("Connector is connected. Subscribing to topics...")
+            general_facts_topic = "hsp/knowledge/facts/general"
+            weather_topic = "hsp/knowledge/facts/weather/#" # Subscribe to all weather subtopics
+
+            connector.subscribe(general_facts_topic)
+            connector.subscribe(weather_topic)
+
+            await asyncio.sleep(1) # Allow subscriptions to complete
+
+            print("\nPublishing a sample fact...")
+            sample_fact_payload: FactPayload = {
+              "id": f"fact_weather_{uuid.uuid4()}",
+              "statement_type": "natural_language",
+              "statement_nl": "The forecast for tomorrow is partly cloudy.",
+              # source_ai_id is added by _build_hsp_envelope using self.ai_id
+              "timestamp_created": datetime.now(timezone.utc).isoformat(),
+              "confidence_score": 0.80,
+              "context": {"location_generic": "local_area"}
+            }
+            connector.publish_fact(sample_fact_payload, topic=general_facts_topic)
+
+            print("\nPublishing another sample fact to a specific weather subtopic...")
+            specific_weather_fact: FactPayload = {
+              "id": f"fact_temp_{uuid.uuid4()}",
+              "statement_type": "semantic_triple",
+              "statement_structured": {"subject_uri": "hsp:env:city_A_temp", "predicate_uri": "hsp:property:hasValueCelsius", "object_literal": 25},
+              "timestamp_created": datetime.now(timezone.utc).isoformat(),
+              "confidence_score": 0.99,
+            }
+            connector.publish_fact(specific_weather_fact, topic="hsp/knowledge/facts/weather/city_A/temperature")
+
+            print("\nExample running. Listening for messages for 20 seconds...")
+            print("Try publishing messages to the subscribed topics using an MQTT client (e.g., MQTT Explorer or mosquitto_pub).")
+            print(f"  mosquitto_pub -h localhost -t '{general_facts_topic}' -m '{{\"hsp_envelope_version\": \"0.1\", ...}}'")
+            await asyncio.sleep(20)
+        else:
+            print("Failed to connect to MQTT broker for example.")
+
+        connector.disconnect()
+        print("HSP Connector example finished.")
+    else:
+        print("Initial connection call failed.")
+
+if __name__ == "__main__":
+    # To run this example:
+    # 1. Ensure you have an MQTT broker running (e.g., `docker run -it -p 1883:1883 -p 9001:9001 eclipse-mosquitto`)
+    # 2. Install paho-mqtt: `pip install paho-mqtt`
+    # 3. Uncomment the next line to run:
+    # asyncio.run(example_hsp_usage())
+    pass

--- a/src/hsp/types.py
+++ b/src/hsp/types.py
@@ -1,0 +1,153 @@
+from typing import TypedDict, Optional, List, Dict, Any, Literal
+
+# For TypedDict, 'Required' is implicitly all keys unless total=False.
+# For explicit Required/Optional with total=False, Python 3.9+ can use:
+# from typing import TypedDict, Required, NotRequired (Python 3.11+)
+# For broader compatibility (3.8+ for TypedDict itself, 3.9 for Literal with TypedDict effectively):
+# We will assume Python 3.9+ as per project README. 'Required' is not a standard generic type alias.
+# Standard TypedDict: if total=True (default), all keys are required.
+# If total=False, all keys are potentially optional (NotRequired).
+# To mix, you'd define multiple TypedDicts and inherit.
+# For simplicity here, we'll use `Optional` for non-mandatory fields and assume mandatory ones are checked by logic.
+# Or, use Pydantic later for proper validation.
+
+# Let's use `total=False` for payloads where many fields are optional, and `total=True` (default) for envelope parts that are mostly required.
+
+class HSPFactStatementStructured(TypedDict, total=False):
+    subject_uri: str # Required if this structure is used
+    predicate_uri: str # Required if this structure is used
+    object_literal: Any
+    object_uri: str
+    object_datatype: str
+
+class HSPOriginalSourceInfo(TypedDict, total=False):
+    type: str # Required if this structure is used, e.g., "url", "document_id"
+    identifier: str # Required if this structure is used
+
+class HSPFactPayload(TypedDict, total=False):
+    id: str  # UUID, considered required for a fact instance
+    statement_type: Literal["natural_language", "semantic_triple", "json_ld"] # Required
+    statement_nl: str
+    statement_structured: HSPFactStatementStructured | Dict[str, Any] # Dict for json_ld
+    source_ai_id: str # DID or URI, Required
+    original_source_info: HSPOriginalSourceInfo
+    timestamp_created: str  # ISO 8601 UTC, Required
+    timestamp_observed: str  # ISO 8601 UTC
+    confidence_score: float  # 0.0-1.0, Required
+    weight: float  # Default 1.0
+    valid_from: str  # ISO 8601 UTC
+    valid_until: str  # ISO 8601 UTC
+    context: Dict[str, Any]
+    tags: List[str]
+    access_policy_id: str
+
+class HSPSecurityParameters(TypedDict, total=False):
+    signature_algorithm: str
+    signature: str
+    encryption_details: Any # Placeholder
+
+class HSPQoSParameters(TypedDict, total=False):
+    priority: Literal["low", "medium", "high"]
+    requires_ack: bool
+    time_to_live_sec: int
+
+class HSPRoutingInfo(TypedDict, total=False):
+    hops: List[str]
+    final_destination_ai_id: str
+
+class HSPMessageEnvelope(TypedDict): # total=True by default, all keys are required
+    hsp_envelope_version: str
+    message_id: str  # UUID
+    correlation_id: Optional[str]  # UUID
+    sender_ai_id: str  # DID or URI
+    recipient_ai_id: str  # DID, URI, or Topic URI
+    timestamp_sent: str  # ISO 8601 UTC
+    message_type: str  # e.g., "HSP::Fact_v0.1"
+    protocol_version: str # HSP specification version
+    communication_pattern: Literal[
+        "publish", "request", "response",
+        "stream_data", "stream_ack",
+        "acknowledgement", "negative_acknowledgement"
+    ]
+    security_parameters: Optional[HSPSecurityParameters]
+    qos_parameters: Optional[HSPQoSParameters]
+    routing_info: Optional[HSPRoutingInfo]
+    payload_schema_uri: Optional[str]
+    payload: Dict[str, Any] # Generic payload, specific types like HSPFactPayload for actual data
+
+# Example of a more specific envelope if needed, though payload typing is usually sufficient
+# class HSPFactMessage(HSPMessageEnvelope):
+#     payload: HSPFactPayload
+# This helps if you want to type hint the entire message including a specific payload.
+
+# Other payload types from HSP_SPECIFICATION.md would be defined here similarly:
+# HSPBeliefPayload, HSPCapabilityAdvertisementPayload, HSPTaskRequestPayload, etc.
+# For now, HSPFactPayload is the primary one for Step 1.2.
+
+class HSPBeliefPayload(HSPFactPayload, total=False): # Inherits from HSPFactPayload, most fields are similar
+    belief_holder_ai_id: str # Required, defaults to source_ai_id if not specified by sender
+    justification_type: Optional[Literal["text", "inference_chain_id", "evidence_ids_list"]]
+    justification: Optional[str | List[str]] # Text, or ID, or list of IDs
+
+class HSPCapabilityAdvertisementPayload(TypedDict, total=False):
+    capability_id: str # Required, unique ID for this capability offering
+    ai_id: str # Required, DID or URI of the AI offering
+    name: str # Required, human-readable name
+    description: str # Required
+    version: str # Required
+    input_schema_uri: Optional[str]
+    input_schema_example: Optional[Dict[str, Any]]
+    output_schema_uri: Optional[str]
+    output_schema_example: Optional[Dict[str, Any]]
+    cost_estimate_template: Optional[Dict[str, Any]]
+    availability_status: Required[Literal["online", "offline", "degraded", "maintenance"]]
+    access_policy_id: Optional[str]
+    tags: Optional[List[str]]
+
+class HSPTaskRequestPayload(TypedDict, total=False):
+    request_id: str # Required, UUID
+    requester_ai_id: str # Required, DID or URI
+    target_ai_id: Optional[str] # DID or URI
+    capability_id_filter: Optional[str]
+    capability_name_filter: Optional[str] # Alternative to id_filter
+    parameters: Required[Dict[str, Any]] # Input parameters for the capability
+    priority: Optional[int] # e.g., 1-10
+    deadline_timestamp: Optional[str] # ISO 8601 UTC
+    callback_address: Optional[str] # URI/topic where TaskResult should be sent
+
+class HSPErrorDetails(TypedDict, total=False):
+    error_code: Required[str]
+    error_message: Required[str]
+    error_context: Optional[Dict[str, Any]]
+
+class HSPTaskResultPayload(TypedDict, total=False):
+    result_id: str # Required, UUID
+    request_id: str # Required, UUID of the TaskRequest
+    executing_ai_id: str # Required, DID or URI
+    status: Required[Literal["success", "failure", "in_progress", "queued", "rejected"]]
+    payload: Optional[Dict[str, Any]] # The actual result data if status is "success"
+    error_details: Optional[HSPErrorDetails] # If status is "failure" or "rejected"
+    timestamp_completed: Optional[str] # ISO 8601 UTC
+    execution_metadata: Optional[Dict[str, Any]] # e.g., {"time_taken_ms": 150}
+
+class HSPEnvironmentalStatePayload(TypedDict, total=False): # Also known as ContextUpdate
+    update_id: str # Required, UUID
+    source_ai_id: str # Required, DID or URI
+    phenomenon_type: str # Required, URI/namespaced string (e.g., "hsp:event:UserMoodShift")
+    parameters: Required[Dict[str, Any]] # Specifics of the state/context
+    timestamp_observed: str # Required, ISO 8601 UTC
+    scope_type: Optional[Literal["global", "session", "project", "custom_group"]]
+    scope_id: Optional[str] # Identifier for the scope
+    relevance_decay_rate: Optional[float]
+
+# Placeholder for Acknowledgement/NegativeAcknowledgement payloads if they need specific structure beyond a simple status
+class HSPAcknowledgementPayload(TypedDict):
+    status: Literal["received", "processed"] # Example statuses
+    ack_timestamp: str # ISO 8601 UTC
+    target_message_id: str # ID of the message being acknowledged
+
+class HSPNegativeAcknowledgementPayload(TypedDict):
+    status: Literal["error", "rejected", "validation_failed"] # Example statuses
+    nack_timestamp: str # ISO 8601 UTC
+    target_message_id: str # ID of the message being NACKed
+    error_details: HSPErrorDetails

--- a/tests/hsp/__init__.py
+++ b/tests/hsp/__init__.py
@@ -1,0 +1,1 @@
+# Test package for HSP related tests

--- a/tests/hsp/test_hsp_integration.py
+++ b/tests/hsp/test_hsp_integration.py
@@ -1,0 +1,322 @@
+import pytest
+import asyncio
+import uuid
+import time
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch, call # Using unittest.mock with pytest
+
+# Ensure src is in path for imports if running tests from root or using pytest from root
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from src.hsp.connector import HSPConnector
+from src.hsp.types import HSPFactPayload, HSPMessageEnvelope # Assuming these are defined
+from src.core_ai.learning.learning_manager import LearningManager
+from src.core_ai.learning.fact_extractor_module import FactExtractorModule
+from src.core_ai.learning.content_analyzer_module import ContentAnalyzerModule
+from src.core_ai.memory.ham_memory_manager import HAMMemoryManager # Will mock this
+from src.services.llm_interface import LLMInterface, LLMInterfaceConfig # Will mock this
+
+# --- Constants for Testing ---
+TEST_AI_ID_MAIN = "did:hsp:test_ai_main_001"
+TEST_AI_ID_PEER = "did:hsp:test_ai_peer_002"
+MQTT_BROKER_ADDRESS = "localhost"
+MQTT_BROKER_PORT = 1883 # Default MQTT port
+
+# General Fact Topic for these tests
+FACT_TOPIC_GENERAL = "hsp/knowledge/facts/test_general"
+FACT_TOPIC_USER_STATEMENTS = "hsp/knowledge/facts/test_user_statements"
+
+
+# --- Mock Classes ---
+class MockLLMInterface(LLMInterface):
+    def __init__(self, config: Optional[LLMInterfaceConfig] = None):
+        super().__init__(config or {"default_provider": "mock"}) #type: ignore
+        self.mock_responses: Dict[str, str] = {}
+
+    def add_mock_response(self, prompt_contains: str, response: str):
+        self.mock_responses[prompt_contains] = response
+
+    def generate_response(self, prompt: str, model_name: Optional[str] = None, params: Optional[Dict[str, Any]] = None) -> str:
+        for key, resp in self.mock_responses.items():
+            if key in prompt:
+                return resp
+        return "{}" # Default empty JSON list for fact extraction if no specific mock
+
+class MockHAM(HAMMemoryManager):
+    def __init__(self):
+        # super().__init__(encryption_key="mock_key_for_test_ham", db_path=None, auto_load=False)
+        self.memory_store: Dict[str, Dict[str, Any]] = {}
+        self.next_id = 1
+        print("Test: Using MockHAMMemoryManager.")
+
+    def store_experience(self, raw_data: Any, data_type: str, metadata: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        mem_id = f"mock_ham_test_{self.next_id}"
+        self.next_id += 1
+        self.memory_store[mem_id] = {"raw_data": raw_data, "data_type": data_type, "metadata": metadata or {}}
+        return mem_id
+    # Add other methods if needed by LearningManager during tests
+
+
+# --- Pytest Fixtures ---
+@pytest.fixture(scope="module") # module scope for potentially shared broker connection if tests are slow
+def event_loop():
+    """Overrides pytest default event loop to enable module-scoped async fixtures if needed,
+       though for paho-mqtt's threaded loop, direct asyncio might not be primary focus here."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.fixture
+def mock_llm():
+    llm = MockLLMInterface()
+    # Pre-configure for FactExtractorModule if it's used to generate facts for publishing
+    llm.add_mock_response(
+        "My favorite food is pizza",
+        '[{"fact_type": "user_preference", "content": {"category": "food", "preference": "pizza"}, "confidence": 0.95}]'
+    )
+    llm.add_mock_response(
+        "Berlin is the capital of Germany", # A statement that might be published
+        '[{"fact_type": "general_statement", "content": {"subject": "Berlin", "relation": "is_capital_of", "object": "Germany"}, "confidence": 0.99}]'
+    )
+    return llm
+
+@pytest.fixture
+def fact_extractor(mock_llm):
+    return FactExtractorModule(llm_interface=mock_llm)
+
+@pytest.fixture
+def ham_manager():
+    return MockHAM()
+
+@pytest.fixture
+def content_analyzer():
+    # Uses default "en_core_web_sm", ensure it's available or tests might be slow/fail on first run
+    return ContentAnalyzerModule()
+
+@pytest.fixture
+def main_ai_hsp_connector():
+    connector = HSPConnector(TEST_AI_ID_MAIN, MQTT_BROKER_ADDRESS, MQTT_BROKER_PORT, client_id_suffix="main_test")
+    if not connector.connect():
+        pytest.fail("Failed to connect main_ai_hsp_connector to MQTT broker. Ensure broker is running.")
+    # Give a moment for connection to establish fully with paho-mqtt's threaded loop
+    time.sleep(0.5)
+    yield connector
+    connector.disconnect()
+    time.sleep(0.1)
+
+
+@pytest.fixture
+def peer_hsp_connector():
+    connector = HSPConnector(TEST_AI_ID_PEER, MQTT_BROKER_ADDRESS, MQTT_BROKER_PORT, client_id_suffix="peer_test")
+    if not connector.connect():
+        pytest.fail("Failed to connect peer_hsp_connector to MQTT broker. Ensure broker is running.")
+    time.sleep(0.5)
+    yield connector
+    connector.disconnect()
+    time.sleep(0.1)
+
+
+@pytest.fixture
+def learning_manager(ham_manager, fact_extractor, content_analyzer, main_ai_hsp_connector):
+    config = {
+        "learning_thresholds": {
+            "min_fact_confidence_to_store": 0.7,
+            "min_fact_confidence_to_share_via_hsp": 0.8,
+            "min_hsp_fact_confidence_to_store": 0.6
+        },
+        "default_hsp_fact_topic": FACT_TOPIC_GENERAL
+    }
+    lm = LearningManager(
+        ai_id=TEST_AI_ID_MAIN,
+        ham_memory_manager=ham_manager,
+        fact_extractor=fact_extractor,
+        content_analyzer=content_analyzer,
+        hsp_connector=main_ai_hsp_connector,
+        operational_config=config
+    )
+    return lm
+
+
+# --- Test Classes ---
+
+class TestHSPFactPublishing:
+    def test_learning_manager_publishes_fact_via_hsp(
+        self, learning_manager, fact_extractor, peer_hsp_connector
+    ):
+        """
+        Test Case 1: Main AI (via LearningManager) extracts and publishes a fact,
+                     Mock Peer's connector verifies reception.
+        """
+        received_facts_on_peer = []
+        def peer_fact_handler(fact_payload: HSPFactPayload, sender_ai_id: str, envelope: HSPMessageEnvelope):
+            print(f"[Peer Test Handler] Received fact from {sender_ai_id}: {fact_payload.get('id')}")
+            if sender_ai_id == TEST_AI_ID_MAIN: # Filter for messages from our main AI
+                received_facts_on_peer.append({"payload": fact_payload, "envelope": envelope})
+
+        peer_hsp_connector.register_on_fact_callback(peer_fact_handler)
+        # Peer subscribes to the topic where LearningManager will publish
+        # LearningManager will use fact_type to determine specific topic or default.
+        # Let's assume "user_statement" facts get published to FACT_TOPIC_USER_STATEMENTS based on LM logic.
+        # The mock LLM for "Berlin..." returns "general_statement".
+        # Let's adjust the LM's default topic or the subscription here for simplicity of this first test.
+        # LM's publish_fact logic: if "user_preference" -> user_preferences topic, "user_statement" -> user_statements topic, else default.
+        # Our mock fact is "general_statement". So it should go to learning_manager.default_hsp_fact_topic (FACT_TOPIC_GENERAL)
+
+        assert peer_hsp_connector.subscribe(FACT_TOPIC_GENERAL), "Peer failed to subscribe to general fact topic"
+        time.sleep(0.2) # Allow subscription to establish
+
+        # Trigger fact extraction and potential publishing in LearningManager
+        # This input should trigger the "Berlin is capital of Germany" mock from LLM (conf 0.99)
+        # which is >= min_fact_confidence_to_share_via_hsp (0.8)
+        print("\n[Test Main AI Publishes] Triggering LM to process text...")
+        learning_manager.process_and_store_learnables(
+            text="Berlin is the capital of Germany.", # This text matches mock_llm
+            user_id="test_user_pub",
+            session_id="test_session_pub",
+            source_interaction_ref="test_interaction_pub_01"
+        )
+
+        # Wait for message to be published and received
+        time.sleep(1) # Increased wait time for MQTT round trip
+
+        assert len(received_facts_on_peer) > 0, "Peer did not receive any facts from main AI"
+
+        received_fact_payload = received_facts_on_peer[0]["payload"]
+        assert received_fact_payload["source_ai_id"] == TEST_AI_ID_MAIN
+        # Check some content from the "Berlin is capital of Germany" fact
+        # The mock LLM returns: {"fact_type": "general_statement", "content": {"subject": "Berlin", ...}, "confidence": 0.99}
+        # LM then constructs HSPFactPayload. statement_structured should be this content.
+        assert received_fact_payload["statement_structured"].get("subject") == "Berlin"
+        assert received_fact_payload["confidence_score"] == 0.99
+
+        print(f"[Test Main AI Publishes] Successfully verified fact reception by peer. Content: {received_fact_payload['statement_structured']}")
+
+
+class TestHSPFactConsumption:
+    @pytest.mark.asyncio # If any part of this test needs async, though paho-mqtt is threaded.
+    async def test_main_ai_consumes_fact_and_updates_kg(
+        self, learning_manager, content_analyzer, peer_hsp_connector, main_ai_hsp_connector
+    ):
+        """
+        Test Case 2: Mock Peer publishes a fact, Main AI's connector receives it,
+                     LearningManager processes it, ContentAnalyzer updates its KG.
+        """
+        # Main AI needs to be subscribed to the topic the peer will publish to.
+        # The handle_incoming_hsp_fact callback in cli/main.py (and thus in LM via that)
+        # is registered with main_ai_hsp_connector.
+        # It's already subscribed to "hsp/knowledge/facts/#" by default in the test fixture setup for main_ai_hsp_connector
+        # (or should be, let's assume main_ai_hsp_connector.subscribe("hsp/knowledge/facts/#") is called).
+        # For this test, let's ensure main_ai_hsp_connector is explicitly subscribed to FACT_TOPIC_GENERAL
+        if not main_ai_hsp_connector.subscribe(FACT_TOPIC_GENERAL):
+             pytest.fail("Main AI connector failed to subscribe to general fact topic")
+        time.sleep(0.2) # Allow subscription
+
+        # Mock the methods that would be called on LM and CA to verify flow
+        learning_manager.process_and_store_hsp_fact = MagicMock(wraps=learning_manager.process_and_store_hsp_fact)
+        content_analyzer.process_hsp_fact_content = MagicMock(wraps=content_analyzer.process_hsp_fact_content)
+
+        # Mock Peer publishes a fact
+        published_fact_id = f"peer_fact_{uuid.uuid4().hex[:6]}"
+        fact_to_publish = HSPFactPayload(
+            id=published_fact_id,
+            statement_type="natural_language",
+            statement_nl="The Mock Peer observes that today is a good day for testing.",
+            source_ai_id=TEST_AI_ID_PEER, # Peer is the source
+            timestamp_created=datetime.now(timezone.utc).isoformat(),
+            confidence_score=0.95,
+            tags=["mock_observation"]
+        )
+        print(f"\n[Test Main AI Consumes] Peer publishing fact: {published_fact_id}")
+        peer_hsp_connector.publish_fact(fact_to_publish, topic=FACT_TOPIC_GENERAL)
+
+        # Wait for message processing
+        await asyncio.sleep(1.0) # Increased wait time
+
+        # Assertions
+        # 1. LearningManager's processing method was called
+        assert learning_manager.process_and_store_hsp_fact.called, \
+            "LearningManager.process_and_store_hsp_fact was not called"
+
+        # Get the arguments it was called with
+        # If called, process_and_store_hsp_fact_args will be a tuple: (args, kwargs)
+        # We expect (hsp_fact_payload, hsp_sender_ai_id, hsp_envelope)
+        call_args_list = learning_manager.process_and_store_hsp_fact.call_args_list
+        assert len(call_args_list) > 0, "process_and_store_hsp_fact call_args_list is empty"
+
+        args_tuple, _ = call_args_list[0] # Get args from the first call
+        received_payload_in_lm = args_tuple[0]
+        sender_in_lm = args_tuple[1]
+
+        assert sender_in_lm == TEST_AI_ID_PEER
+        assert received_payload_in_lm.get("id") == published_fact_id
+
+        # 2. ContentAnalyzer's processing method was called
+        assert content_analyzer.process_hsp_fact_content.called, \
+            "ContentAnalyzer.process_hsp_fact_content was not called"
+
+        ca_call_args_list = content_analyzer.process_hsp_fact_content.call_args_list
+        assert len(ca_call_args_list) > 0, "process_hsp_fact_content call_args_list is empty"
+
+        ca_args_tuple, _ = ca_call_args_list[0]
+        payload_in_ca = ca_args_tuple[0] # hsp_fact_payload (as dict)
+        sender_in_ca = ca_args_tuple[1] # source_ai_id
+
+        assert sender_in_ca == TEST_AI_ID_PEER # This is hsp_sender_ai_id from LM
+        assert payload_in_ca.get("id") == published_fact_id
+
+        # 3. Check ContentAnalyzer's graph for updates
+        # The NL fact "The Mock Peer observes that today is a good day for testing."
+        # should result in some nodes/edges.
+        # Example: find a node related to "Mock Peer" or "good day"
+        # This requires ContentAnalyzer to have run its NLP pipeline.
+        graph = content_analyzer.graph
+        assert graph.number_of_nodes() > 0, "ContentAnalyzer graph has no nodes after processing HSP fact."
+
+        # Example check: Look for an entity that might have been created from the NL
+        # This is highly dependent on the NLP model and extraction logic.
+        found_test_related_node = False
+        test_node_label = ""
+        for node_id, node_data in graph.nodes(data=True):
+            label = node_data.get("label", "")
+            if "mock peer" in label.lower() or "good day" in label.lower() or "testing" in label.lower():
+                found_test_related_node = True
+                test_node_label = label
+                # Check for hsp_source_info attribute added by process_hsp_fact_content
+                assert 'hsp_source_info' in node_data
+                assert node_data['hsp_source_info']['origin_fact_id'] == published_fact_id
+                assert node_data['hsp_source_info']['source_ai'] == TEST_AI_ID_PEER
+                break
+
+        assert found_test_related_node, f"Could not find a relevant node in ContentAnalyzer graph. Graph nodes: {list(graph.nodes(data=True))}"
+        print(f"[Test Main AI Consumes] Successfully verified fact consumption and KG update (found node: '{test_node_label}').")
+
+        # TODO: Add a test case for structured (semantic triple) fact consumption by ContentAnalyzer.
+        # This would involve peer_hsp_connector publishing a fact with statement_type="semantic_triple"
+        # and then asserting specific nodes/edges based on those triples in content_analyzer.graph.
+
+# To run these tests:
+# 1. Ensure an MQTT broker is running on localhost:1883
+# 2. From the project root: pytest tests/hsp/test_hsp_integration.py
+#
+# Note: These tests involve network communication and timing, so they might be
+#       a bit slower or occasionally flaky if network/broker is unstable.
+#       Proper async handling with an async MQTT client might improve reliability
+#       if paho-mqtt's threaded loop causes issues in complex pytest scenarios.
+#       For now, `time.sleep` is used for simplicity to allow messages to propagate.
+```
+
+This sets up:
+*   Mock LLM and HAM.
+*   Pytest fixtures for `HSPConnector` instances (one for "main AI", one for "peer AI"), `LearningManager`, `FactExtractorModule`, and `ContentAnalyzerModule`.
+*   `TestHSPFactPublishing` class with `test_learning_manager_publishes_fact_via_hsp`.
+*   `TestHSPFactConsumption` class with `test_main_ai_consumes_fact_and_updates_kg`.
+
+**Important Considerations for these tests:**
+*   **MQTT Broker Dependency:** These tests require an MQTT broker running at `localhost:1883`. This is an external dependency.
+*   **Timing (`time.sleep`):** `paho-mqtt` runs its network loop in a separate thread. `time.sleep()` is used to give time for messages to be sent, received, and processed. This can make tests slower and potentially a bit flaky. For more robust async testing with MQTT, an `asyncio`-native MQTT client (`aio-mqtt`, `gmqtt`) would be better, allowing `await` for operations. However, `paho-mqtt` is what `HSPConnector` currently uses.
+*   **Graph Inspection:** Testing the `ContentAnalyzerModule`'s graph update requires making some assumptions about what nodes/edges will be created from the NLP processing of the test fact. This can be brittle if the NLP model or extraction logic changes. More specific query methods on `ContentAnalyzerModule` might be needed for robust testing of its state.
+*   **Scope of Mocks:** `LLMInterface` and `HAMMemoryManager` are mocked to isolate the HSP interaction and KG update logic.
+
+I'll now create this file.


### PR DESCRIPTION
This commit includes the initial design and implementation for the Heterogeneous Synchronization Protocol (HSP).

Key changes:

Phase 0: HSP Design
- Created docs/HSP_SPECIFICATION.md outlining core concepts, data payloads (Fact, Belief, CapabilityAdvertisement, TaskRequest, etc.), communication patterns (Pub/Sub, Req/Rep), message envelope, and interaction logic.

Phase 1: Initial HSP Implementation & Adaptation
- Added src/hsp/connector.py with HSPConnector class using paho-mqtt for communication.
- Added src/hsp/types.py with TypedDict definitions for HSP message payloads and envelope.
- Integrated LearningManager to publish facts (from FactExtractorModule) via HSPConnector.
- Developed scripts/mock_hsp_peer.py to simulate another AI on the HSP network for testing.
- Added paho-mqtt to requirements.txt.

Phase 2 (Partial): Broader Internal Refactoring & Testing
- Enabled LearningManager to process incoming HSPFactPayloads received via HSPConnector.
- Integrated ContentAnalyzerModule to process content from these HSP facts and update its internal knowledge graph.
- Updated cli/main.py to initialize and wire these HSP components (HSPConnector, LearningManager with ContentAnalyzerModule) and register callbacks for incoming HSP facts.
- Created initial integration test structure in tests/hsp/test_hsp_integration.py with pytest, including mocks and fixtures for testing the HSP publish/consume loop.