### PR TITLE
refactor: Apply internal data standards to supporting AI modules and …

### DIFF
--- a/src/hsp/connector.py
+++ b/src/hsp/connector.py
@@ -383,22 +383,22 @@ async def example_hsp_usage():
             await asyncio.sleep(1) # Allow subscriptions to complete
 
             print("\nPublishing a sample fact...")
-            sample_fact_payload: FactPayload = {
-              "id": f"fact_weather_{uuid.uuid4()}",
+            sample_fact_payload: HSPFactPayload = { # Changed FactPayload to HSPFactPayload
+              "id": f"fact_weather_{uuid.uuid4().hex[:6]}", # Use hex for shorter UUID part
               "statement_type": "natural_language",
               "statement_nl": "The forecast for tomorrow is partly cloudy.",
-              # source_ai_id is added by _build_hsp_envelope using self.ai_id
+              "source_ai_id": my_ai_id, # Explicitly set for clarity, though _build_hsp_envelope uses self.ai_id
               "timestamp_created": datetime.now(timezone.utc).isoformat(),
               "confidence_score": 0.80,
-              "context": {"location_generic": "local_area"}
-            }
+              "tags": ["weather", "forecast"] # Added tags
+            } # type: ignore # Added type: ignore for potentially missing optional fields if HSPFactPayload is strict
             connector.publish_fact(sample_fact_payload, topic=general_facts_topic)
 
             print("\nPublishing another sample fact to a specific weather subtopic...")
-            specific_weather_fact: FactPayload = {
-              "id": f"fact_temp_{uuid.uuid4()}",
+            specific_weather_fact: HSPFactPayload = { # Changed FactPayload to HSPFactPayload
+              "id": f"fact_temp_{uuid.uuid4().hex[:6]}",  # Use hex for shorter UUID part
               "statement_type": "semantic_triple",
-              "statement_structured": {"subject_uri": "hsp:env:city_A_temp", "predicate_uri": "hsp:property:hasValueCelsius", "object_literal": 25},
+              "statement_structured": {"subject_uri": "hsp:env:city_A_temp", "predicate_uri": "hsp:property:hasValueCelsius", "object_literal": 25}, # type: ignore
               "timestamp_created": datetime.now(timezone.utc).isoformat(),
               "confidence_score": 0.99,
             }

--- a/src/shared/types/common_types.py
+++ b/src/shared/types/common_types.py
@@ -414,6 +414,42 @@ class HAMRecallResult(TypedDict):
     metadata: Dict[str, Any] # The metadata associated with the memory record. Should conform to DialogueMemoryEntryMetadata where applicable.
 # --- End HAMMemoryManager Specific Internal Types ---
 
+# --- Fact Extractor Module Specific Types ---
+class ExtractedFactContentPreference(TypedDict, total=False):
+    """Content structure for a 'user_preference' fact."""
+    category: Required[str]
+    preference: Required[str]
+    liked: Optional[bool] # True for like, False for dislike, None if not specified
+
+class ExtractedFactContentStatement(TypedDict, total=False):
+    """Content structure for a 'user_statement' fact (e.g., about self)."""
+    attribute: Required[str]
+    value: Required[Any] # Value can be string, number, boolean etc.
+
+# Union for the 'content' field of an ExtractedFact
+ExtractedFactContent = Union[ExtractedFactContentPreference, ExtractedFactContentStatement, Dict[str, Any]]
+
+class ExtractedFact(TypedDict):
+    """
+    Represents a single fact extracted by the FactExtractorModule from user text.
+    This is the structure LearningManager receives.
+    """
+    fact_type: Required[str]  # e.g., "user_preference", "user_statement"
+    content: Required[ExtractedFactContent] # The structured content of the fact
+    confidence: Required[float] # LLM's confidence in this extraction (0.0-1.0)
+# --- End Fact Extractor Module Specific Types ---
+
+# --- LLM Interface Specific Types ---
+class LLMModelInfo(TypedDict, total=False):
+    """Information about an available LLM model."""
+    id: Required[str] # Model ID or name (e.g., "nous-hermes2:latest", "gpt-3.5-turbo")
+    provider: Required[str]  # e.g., "ollama", "openai", "mock"
+    name: Optional[str] # Often same as id, but can be more descriptive
+    family: Optional[str] # e.g., "llama", "gpt"
+    size_bytes: Optional[int]
+    modified_at: Optional[str] # ISO datetime string
+# --- End LLM Interface Specific Types ---
+
 
 print("common_types.py placeholder loaded.")
 

--- a/tests/core_ai/service_discovery/test_service_discovery_module.py
+++ b/tests/core_ai/service_discovery/test_service_discovery_module.py
@@ -1,0 +1,165 @@
+import unittest
+from unittest.mock import MagicMock
+from datetime import datetime, timezone
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', 'src')))
+
+from core_ai.service_discovery.service_discovery_module import ServiceDiscoveryModule, StoredCapabilityInfo
+from core_ai.trust_manager.trust_manager_module import TrustManager
+from hsp.types import HSPCapabilityAdvertisementPayload, HSPMessageEnvelope
+
+class TestServiceDiscoveryModule(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_trust_manager = MagicMock(spec=TrustManager)
+        self.discovery_module_with_trust = ServiceDiscoveryModule(trust_manager=self.mock_trust_manager)
+        self.discovery_module_no_trust = ServiceDiscoveryModule(trust_manager=None)
+
+    def _create_sample_capability_payload(self, cap_id: str, ai_id: str, name: str, tags: list = None) -> HSPCapabilityAdvertisementPayload:
+        return HSPCapabilityAdvertisementPayload(
+            capability_id=cap_id,
+            ai_id=ai_id,
+            name=name,
+            description=f"Description for {name}",
+            version="1.0",
+            availability_status="online",
+            tags=tags or []
+        )
+
+    def _create_sample_envelope(self, sender_ai_id: str) -> HSPMessageEnvelope:
+        return HSPMessageEnvelope(
+            message_id="test_msg_id",
+            sender_ai_id=sender_ai_id,
+            recipient_ai_id="test_recipient",
+            timestamp_sent=datetime.now(timezone.utc).isoformat(),
+            message_type="HSP::CapabilityAdvertisement_v0.1",
+            protocol_version="0.1",
+            communication_pattern="publish",
+            payload={} # Actual payload set by caller
+        )
+
+    def test_process_capability_advertisement_with_trust_manager(self):
+        cap_payload = self._create_sample_capability_payload("cap1", "ai1", "Translator")
+        sender_ai_id = "ai1"
+        envelope = self._create_sample_envelope(sender_ai_id)
+
+        self.mock_trust_manager.get_trust_score.return_value = 0.75
+
+        self.discovery_module_with_trust.process_capability_advertisement(cap_payload, sender_ai_id, envelope)
+
+        self.assertIn("cap1", self.discovery_module_with_trust.known_capabilities)
+        stored_cap = self.discovery_module_with_trust.known_capabilities["cap1"]
+
+        self.assertEqual(stored_cap.get("name"), "Translator")
+        self.assertEqual(stored_cap.get("_trust_score"), 0.75)
+        self.mock_trust_manager.get_trust_score.assert_called_once_with("ai1")
+        self.assertIn("cap1", self.discovery_module_with_trust.last_seen)
+
+    def test_process_capability_advertisement_no_trust_manager(self):
+        cap_payload = self._create_sample_capability_payload("cap2", "ai2", "Summarizer")
+        sender_ai_id = "ai2"
+        envelope = self._create_sample_envelope(sender_ai_id)
+
+        self.discovery_module_no_trust.process_capability_advertisement(cap_payload, sender_ai_id, envelope)
+
+        self.assertIn("cap2", self.discovery_module_no_trust.known_capabilities)
+        stored_cap = self.discovery_module_no_trust.known_capabilities["cap2"]
+
+        self.assertEqual(stored_cap.get("name"), "Summarizer")
+        self.assertEqual(stored_cap.get("_trust_score"), TrustManager.DEFAULT_TRUST_SCORE) # Should use default
+        self.assertIn("cap2", self.discovery_module_no_trust.last_seen)
+
+    def test_process_capability_advertisement_missing_id(self):
+        cap_payload_no_id = self._create_sample_capability_payload("cap3", "ai3", "Test")
+        del cap_payload_no_id["capability_id"] # Remove essential field
+        sender_ai_id = "ai3"
+        envelope = self._create_sample_envelope(sender_ai_id)
+
+        with patch('builtins.print') as mock_print:
+            self.discovery_module_no_trust.process_capability_advertisement(cap_payload_no_id, sender_ai_id, envelope) # type: ignore
+            self.assertNotIn("cap3", self.discovery_module_no_trust.known_capabilities)
+            mock_print.assert_any_call("ServiceDiscoveryModule: Received capability advertisement without a capability_id. Skipping.")
+
+    def test_find_capabilities_by_name_and_id(self):
+        cap1 = self._create_sample_capability_payload("id1", "ai1", "ServiceA")
+        cap2 = self._create_sample_capability_payload("id2", "ai2", "ServiceB")
+        self.discovery_module_no_trust.process_capability_advertisement(cap1, "ai1", self._create_sample_envelope("ai1"))
+        self.discovery_module_no_trust.process_capability_advertisement(cap2, "ai2", self._create_sample_envelope("ai2"))
+
+        results_name: List[StoredCapabilityInfo] = self.discovery_module_no_trust.find_capabilities(capability_name_filter="ServiceA")
+        self.assertEqual(len(results_name), 1)
+        self.assertEqual(results_name[0].get("capability_id"), "id1")
+
+        results_id: List[StoredCapabilityInfo] = self.discovery_module_no_trust.find_capabilities(capability_id_filter="id2")
+        self.assertEqual(len(results_id), 1)
+        self.assertEqual(results_id[0].get("name"), "ServiceB")
+
+    def test_find_capabilities_with_trust_filter_and_sort(self):
+        cap1 = self._create_sample_capability_payload("id1", "ai_high_trust", "ServiceHigh")
+        cap2 = self._create_sample_capability_payload("id2", "ai_low_trust", "ServiceLow")
+        cap3 = self._create_sample_capability_payload("id3", "ai_mid_trust", "ServiceMid")
+
+        self.mock_trust_manager.get_trust_score.side_effect = lambda ai_id: {"ai_high_trust": 0.9, "ai_low_trust": 0.3, "ai_mid_trust": 0.6}.get(ai_id, 0.5)
+
+        self.discovery_module_with_trust.process_capability_advertisement(cap1, "ai_high_trust", self._create_sample_envelope("ai_high_trust"))
+        self.discovery_module_with_trust.process_capability_advertisement(cap2, "ai_low_trust", self._create_sample_envelope("ai_low_trust"))
+        self.discovery_module_with_trust.process_capability_advertisement(cap3, "ai_mid_trust", self._create_sample_envelope("ai_mid_trust"))
+
+        # Test filtering
+        results_min_trust: List[StoredCapabilityInfo] = self.discovery_module_with_trust.find_capabilities(min_trust_score=0.5)
+        self.assertEqual(len(results_min_trust), 2) # Should include high (0.9) and mid (0.6)
+        self.assertNotIn("id2", [c.get("capability_id") for c in results_min_trust])
+
+        # Test sorting
+        results_sorted: List[StoredCapabilityInfo] = self.discovery_module_with_trust.find_capabilities(sort_by_trust=True)
+        self.assertEqual(len(results_sorted), 3)
+        self.assertEqual(results_sorted[0].get("capability_id"), "id1") # Highest trust
+        self.assertEqual(results_sorted[1].get("capability_id"), "id3") # Mid trust
+        self.assertEqual(results_sorted[2].get("capability_id"), "id2") # Low trust
+
+        # Test filtering and sorting
+        results_filtered_sorted: List[StoredCapabilityInfo] = self.discovery_module_with_trust.find_capabilities(min_trust_score=0.5, sort_by_trust=True)
+        self.assertEqual(len(results_filtered_sorted), 2)
+        self.assertEqual(results_filtered_sorted[0].get("capability_id"), "id1") # High
+        self.assertEqual(results_filtered_sorted[1].get("capability_id"), "id3") # Mid
+
+    def test_get_capability_by_id(self):
+        cap1 = self._create_sample_capability_payload("id1", "ai1", "ServiceA")
+        self.discovery_module_no_trust.process_capability_advertisement(cap1, "ai1", self._create_sample_envelope("ai1"))
+
+        found_cap: Optional[StoredCapabilityInfo] = self.discovery_module_no_trust.get_capability_by_id("id1")
+        self.assertIsNotNone(found_cap)
+        self.assertEqual(found_cap.get("name"), "ServiceA") # type: ignore
+
+        not_found_cap = self.discovery_module_no_trust.get_capability_by_id("nonexistent")
+        self.assertIsNone(not_found_cap)
+
+    def test_remove_capability(self):
+        cap1 = self._create_sample_capability_payload("id1", "ai1", "ServiceA")
+        self.discovery_module_no_trust.process_capability_advertisement(cap1, "ai1", self._create_sample_envelope("ai1"))
+        self.assertIn("id1", self.discovery_module_no_trust.known_capabilities)
+
+        removed = self.discovery_module_no_trust.remove_capability("id1")
+        self.assertTrue(removed)
+        self.assertNotIn("id1", self.discovery_module_no_trust.known_capabilities)
+        self.assertNotIn("id1", self.discovery_module_no_trust.last_seen)
+
+        removed_again = self.discovery_module_no_trust.remove_capability("id1")
+        self.assertFalse(removed_again)
+
+    def test_get_all_capabilities(self):
+        cap1 = self._create_sample_capability_payload("id1", "ai1", "ServiceA")
+        cap2 = self._create_sample_capability_payload("id2", "ai2", "ServiceB")
+        self.discovery_module_no_trust.process_capability_advertisement(cap1, "ai1", self._create_sample_envelope("ai1"))
+        self.discovery_module_no_trust.process_capability_advertisement(cap2, "ai2", self._create_sample_envelope("ai2"))
+
+        all_caps: List[StoredCapabilityInfo] = self.discovery_module_no_trust.get_all_capabilities()
+        self.assertEqual(len(all_caps), 2)
+        cap_ids_present = {c.get("capability_id") for c in all_caps}
+        self.assertIn("id1", cap_ids_present)
+        self.assertIn("id2", cap_ids_present)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
…services

- Refined data typing in ServiceDiscoveryModule (using StoredCapabilityInfo), ContentAnalyzerModule (using CAHSPFactProcessingResult), FactExtractorModule (using ExtractedFact), and LLMInterface (using LLMModelInfo).
- Created unit tests for ServiceDiscoveryModule.
- Updated existing unit tests and standalone test blocks for affected modules to align with new type hints and ensure consistency.
- TrustManager and HSPConnector reviewed and confirmed largely compliant with minor test block updates.