### PR TITLE
refactor: Apply internal data standards to supporting AI modules and …

### DIFF
--- a/docs/INTERNAL_DATA_STANDARDS.md
+++ b/docs/INTERNAL_DATA_STANDARDS.md
@@ -73,3 +73,7 @@ The primary mechanism for defining structured data objects for internal exchange
 *   **HSP:** The Heterogeneous Synchronization Protocol (`src/hsp/types.py` and `docs/HSP_SPECIFICATION.md`) defines data structures and protocols for communication *between separate AI instances* over a network. While some HSP payload structures might inform or be used internally, their primary definition is for inter-AI interoperability. Internal representations may sometimes be simpler or more tailored to the AI's internal logic.
 
 By adhering to these standards, we aim to create a more robust, understandable, and maintainable codebase.
+
+## 9. Ongoing Diligence
+
+These standards should be applied to all new Python code involving structured data exchange between modules. Existing code should be refactored to adhere to these standards opportunistically or during planned refactoring efforts for specific components. Regular review of `src/shared/types/common_types.py` for consolidation and clarity is also encouraged.

--- a/src/core_ai/learning/content_analyzer_module.py
+++ b/src/core_ai/learning/content_analyzer_module.py
@@ -9,6 +9,23 @@ from hsp.types import HSPFactPayload # Import HSPFactPayload
 
 from spacy.matcher import Matcher # Added Matcher
 
+# --- Types for process_hsp_fact_content return value ---
+class ProcessedTripleInfo(TypedDict):
+    """Detailed information about a semantic triple processed by ContentAnalyzerModule."""
+    subject_id: str
+    predicate_type: str
+    object_id: str
+    original_subject_uri: str
+    original_predicate_uri: str
+    original_object_uri_or_literal: Any
+    object_is_uri: bool
+
+class CAHSPFactProcessingResult(TypedDict):
+    """Result structure from ContentAnalyzerModule's processing of an HSP fact."""
+    updated_graph: bool
+    processed_triple: Optional[ProcessedTripleInfo]
+# --- End Types ---
+
 # Attempt to load a spaCy model
 # For a real application, model management (downloading, versioning) would be more robust.
 try:
@@ -689,23 +706,6 @@ class ContentAnalyzerModule:
 
         print(f"NetworkX graph constructed: {nx_graph.number_of_nodes()} nodes, {nx_graph.number_of_edges()} edges.")
         return knowledge_graph_data, nx_graph
-
-# --- Types for process_hsp_fact_content return value ---
-class ProcessedTripleInfo(TypedDict):
-    """Detailed information about a semantic triple processed by ContentAnalyzerModule."""
-    subject_id: str
-    predicate_type: str
-    object_id: str
-    original_subject_uri: str
-    original_predicate_uri: str
-    original_object_uri_or_literal: Any
-    object_is_uri: bool
-
-class CAHSPFactProcessingResult(TypedDict):
-    """Result structure from ContentAnalyzerModule's processing of an HSP fact."""
-    updated_graph: bool
-    processed_triple: Optional[ProcessedTripleInfo]
-# --- End Types ---
 
     def process_hsp_fact_content(self, hsp_fact_payload: HSPFactPayload, source_ai_id: str) -> CAHSPFactProcessingResult:
         """


### PR DESCRIPTION
…services (Batch 2)

- Added new TypedDicts to common_types.py: LLMModelInfo, ExtractedFact, ExtractedFactContentPreference, ExtractedFactContentStatement.
- Refined data typing in ServiceDiscoveryModule (using StoredCapabilityInfo), ContentAnalyzerModule (input HSPFactPayload, output CAHSPFactProcessingResult), FactExtractorModule (output List[ExtractedFact]), and LLMInterface (output List[LLMModelInfo]).
- Created new unit tests for ServiceDiscoveryModule.
- Added new unit tests for ContentAnalyzerModule.process_hsp_fact_content.
- Reviewed and made minor updates to standalone tests for TrustManager, FactExtractorModule, LLMInterface, and HSPConnector.
- Included fixes to learning_manager.py identified during testing of Phase 3 changes.