### PR TITLE
Add project content organization document

### DIFF
--- a/docs/PROJECT_CONTENT_ORGANIZATION.md
+++ b/docs/PROJECT_CONTENT_ORGANIZATION.md
@@ -1,0 +1,164 @@
+# Unified-AI-Project: Content Organization
+
+## Introduction
+
+This document provides an organized overview of the Unified-AI-Project's content, categorizing key directories and files to aid in understanding the project's structure and the purpose of its various components. This is based on the file structure available as of October 2023.
+
+## 1. Root Directory Files
+
+Key files at the project root:
+
+*   `README.md`: Main entry point for project information, overview, setup, and contribution guidelines.
+*   `MERGE_AND_RESTRUCTURE_PLAN.md`: Documents the initial project structure, merge strategy, and architectural principles.
+*   `.gitignore`: Specifies intentionally untracked files that Git should ignore.
+*   `requirements.txt`: Lists Python dependencies for the project.
+*   `package.json`: Defines Node.js dependencies and scripts for the project (e.g., for Electron app).
+*   `.env.example`: Example environment variable file; a `.env` file should be created from this for local configuration.
+
+## 2. Source Code (`src/`)
+
+Contains the core Python source code for the AI and its services.
+
+### 2.1. Core AI Logic (`src/core_ai/`)
+
+Houses the central intelligence and decision-making components of the AI.
+
+*   **`dialogue/`**:
+    *   `dialogue_manager.py`: Orchestrates conversation flow, integrates various AI components, and generates responses.
+*   **`memory/`**:
+    *   `ham_memory_manager.py`: Implements the Hierarchical Associative Memory for storing and retrieving experiences, learned facts, and dialogue context.
+*   **`learning/`**:
+    *   `learning_manager.py`: Coordinates the learning process, including fact extraction and storage.
+    *   `fact_extractor_module.py`: Extracts structured facts from dialogue.
+    *   `self_critique_module.py`: Evaluates AI responses for quality and coherence.
+    *   `content_analyzer_module.py`: Aims for deep context understanding by analyzing text to create knowledge graphs (utilizes spaCy and NetworkX).
+*   **`personality/`**:
+    *   `personality_manager.py`: Manages different AI personalities and their profiles.
+*   **`formula_engine/`**: Contains the logic for the rule-based formula engine that can trigger actions or responses.
+*   **`code_understanding/`**:
+    *   `lightweight_code_model.py`: Provides basic static analysis of Python code, particularly for understanding tool structures.
+*   **`service_discovery/`**:
+    *   `service_discovery_module.py`: Manages discovery and registry of capabilities advertised by other AIs on the HSP network.
+*   **`trust_manager/`**:
+    *   `trust_manager_module.py`: Manages trust scores for interactions with other AI peers in the HSP network.
+*   `emotion_system.py`: Manages and simulates the AI's emotional state.
+*   `crisis_system.py`: Assesses input for crisis situations and can trigger appropriate responses.
+*   `time_system.py`: Provides time-related context (e.g., time of day).
+
+### 2.2. Heterogeneous Synchronization Protocol (`src/hsp/`)
+
+Defines the protocol and connector for inter-AI communication.
+
+*   `connector.py`: Manages MQTT-based communication with the HSP network, handles message serialization/deserialization, and implements features like automatic reconnection and ACK sending.
+*   `types.py`: Defines `TypedDict` structures for various HSP message envelopes and payloads.
+
+### 2.3. Tools (`src/tools/`)
+
+Contains internal "tools" that the AI can use to augment its capabilities.
+
+*   `tool_dispatcher.py`: Enables the AI to select and use various tools.
+*   `math_tool.py`, `logic_tool.py`, `translation_tool.py`: Example or actual implementations of specific tools.
+*   Subdirectories like `math_model/`, `logic_model/`, `translation_model/` likely contain machine learning models or data related to these tools.
+*   `js_tool_dispatcher/`: Appears to be for dispatching tools implemented in JavaScript.
+
+### 2.4. Fragmenta Meta-Orchestration (`src/fragmenta/` and `src/modules_fragmenta/`)
+
+System for managing complex tasks and large data.
+
+*   `fragmenta/fragmenta_orchestrator.py`: Placeholder and basic implementation for the system that will manage complex tasks, chunk data, and coordinate modules.
+*   `modules_fragmenta/`: Contains specialized processing modules potentially used by Fragmenta:
+    *   `element_layer.py`: Placeholder for processing data at an elemental level.
+    *   `vision_tone_inverter.py`: Placeholder for adjusting visual representations based on tone.
+
+### 2.5. Services (`src/services/`)
+
+Backend services, including API servers and interfaces to external systems.
+
+*   `main_api_server.py`: FastAPI application providing API endpoints for interacting with the AI.
+*   `llm_interface.py`: Standardized interface for interacting with various Large Language Models (e.g., Ollama, OpenAI).
+*   `sandbox_executor.py`: For safely executing code, likely used in tool drafting or other dynamic code execution scenarios.
+*   `audio_service.py`, `vision_service.py`: Placeholders or implementations for audio and vision processing capabilities.
+*   `node_services/`: Contains a Node.js server, possibly for supporting JavaScript-based tools or UI backend components.
+*   `api_models.py`: Defines Pydantic models for API request/response validation.
+
+### 2.6. Shared Utilities (`src/shared/`)
+
+Common utilities, types, and configurations used across different parts of the project.
+
+*   `types/common_types.py`: Central repository for common `TypedDict` data structures used for internal data exchange.
+*   Likely contains other shared helper functions or constants.
+
+### 2.7. User Interfaces (Implementations) (`src/interfaces/`)
+
+Code for different ways users can interact with the AI.
+
+*   **`cli/`**:
+    *   `main.py`: Implementation for the Command Line Interface (CLI).
+*   **`electron_app/`**: Contains the source code for the Electron-based desktop application (HTML, CSS, JavaScript for frontend; `main.js` for Electron main process, `preload.js` for context bridge, `renderer.js` for frontend logic).
+
+## 3. Documentation (`docs/`)
+
+Contains project documentation, design specifications, and architectural notes.
+
+*   `README.md` (in root, but effectively project documentation)
+*   `HSP_SPECIFICATION.md`: Detailed specification for the Heterogeneous Synchronization Protocol.
+*   `INTERNAL_DATA_STANDARDS.md`: Guidelines for using `TypedDict` for internal data structures.
+*   `PROJECT_STATUS_SUMMARY.md`: This document, summarizing implemented vs. pending features.
+*   `PROJECT_CONTENT_ORGANIZATION.md`: This document, providing an overview of file organization.
+*   **`architecture/`**: Subdirectory for more detailed architectural documents:
+    *   `DEEP_MAPPING_AND_PERSONALITY_SIMULATION.md`: Discussion on advanced data mapping and personality concepts (includes clarification on "XXX" misinterpretation).
+    *   `ENHANCED_DECOUPLING_STRATEGIES.md`: Identifies areas and strategies for improving module decoupling.
+    *   `Fragmenta_design_spec.md`: Design specification for the Fragmenta meta-orchestration system.
+    *   `HAM_design_spec.md`: Design specification for the Hierarchical Associative Memory.
+    *   `Heterogeneous_Protocol_spec.md`: Likely an older or alternative name/version for HSP specification.
+    *   `MEMORY_SYSTEM.md`: Overview or design notes for the memory system.
+
+## 4. Configuration Files (`configs/`)
+
+Centralized configuration for various aspects of the AI system.
+
+*   `system_config.yaml`: General system-wide configurations.
+*   `api_keys.yaml`: Structure and placeholders for external API keys (actual keys typically via `.env`).
+*   `ontology_mappings.yaml`: Mappings for ontologies, likely used by `ContentAnalyzerModule`.
+*   `version_manifest.json`: Manages versions of different components or data schemas.
+*   **`formula_configs/`**:
+    *   `default_formulas.json`: Defines rules for the Formula Engine.
+*   **`personality_profiles/`**:
+    *   `miko_base.json`: Base personality profile for an AI instance. Other JSON files would define different personalities.
+
+## 5. Test Suites (`tests/`)
+
+Contains unit and integration tests for the project. The directory structure generally mirrors `src/`.
+
+*   `tests/core_ai/`: Tests for core AI components (dialogue, memory, learning, etc.).
+    *   `memory/test_ham_memory_manager.py`: Tests for HAM.
+    *   `dialogue/test_dialogue_manager.py`: Tests for Dialogue Manager.
+*   `tests/fragmenta/`: Tests for Fragmenta.
+*   `tests/hsp/`: Tests for HSP components.
+*   `tests/services/`: Tests for backend services.
+*   `tests/tools/`: Tests for AI tools.
+*   ... and so on for other modules.
+
+## 6. Scripts (`scripts/`)
+
+Utility scripts for various tasks like data processing, setup, or prototyping.
+
+*   **`data_processing/`**:
+    *   `ingest_processed_logs_to_ham.py`: Script to ingest processed log data into HAM.
+    *   `process_copilot_logs.py`: Script to process Copilot activity logs.
+*   **`data_migration/`**: Placeholder for data migration scripts.
+*   **`prototypes/`**: Contains prototype code, e.g., `miko_core_ham_prototype.py`.
+*   `project_setup_utils.py`: Utilities for project setup.
+*   `mock_hsp_peer.py`: A script to mock an HSP peer for testing communication.
+
+## 7. Data Storage (`data/`)
+
+Contains various data used by or generated by the AI. This directory is typically in `.gitignore` for large datasets or sensitive information but contains subdirectories for different data types.
+
+*   **`chat_histories/`**: Stores chat logs (e.g., `ollama_chat_histories.json`).
+*   **`firebase/`**: Configuration files related to Firebase integration.
+*   **`knowledge_bases/`**: Stores structured knowledge data (e.g., emotion maps, personality definitions, formulas).
+*   **`processed_data/`**: For data that has been processed from raw sources, including HAM memory files (e.g., `dialogue_context_memory.json`).
+*   **`raw_datasets/`**: For raw input data before processing.
+
+This organization should help in navigating the project and understanding where different functionalities reside.

--- a/docs/architecture/ENHANCED_DECOUPLING_STRATEGIES.md
+++ b/docs/architecture/ENHANCED_DECOUPLING_STRATEGIES.md
@@ -1,0 +1,126 @@
+# Enhanced Decoupling Strategies for Unified-AI-Project
+
+## 1. Introduction
+
+Decoupling in software architecture refers to reducing the interdependencies between different modules or components of a system. The goal is to allow components to be developed, modified, tested, and scaled more independently. In a complex system like the Unified-AI-Project, effective decoupling is crucial for:
+
+*   **Mitigating Over-Sensitization:** Preventing a state where small changes in one module lead to disproportionate, widespread, or unintended consequences in other modules.
+*   **Avoiding Diffusion:** Preventing the blurring of responsibilities, unclear ownership of data, or the excessive spread of detailed state information across modules that don't strictly need it.
+*   **Improving Maintainability:** Making it easier to understand, modify, and debug individual components without needing to comprehend the entire system in exhaustive detail.
+*   **Enhancing Testability:** Allowing modules to be tested in isolation more effectively.
+*   **Increasing Robustness & Resilience:** Containing failures within module boundaries.
+*   **Facilitating Extensibility:** Making it easier to add new features or replace components.
+
+This document identifies specific areas within the Unified-AI-Project where applying or strengthening decoupling patterns could be beneficial and provides recommendations.
+
+## 2. Identified Areas for Enhanced Decoupling & Recommendations
+
+### 2.1. Emotion System Propagation
+
+*   **Current/Potential Concern:**
+    *   The `EmotionSystem` calculates and maintains the AI's emotional state. If multiple modules (`DialogueManager`, `LearningManager`, `FragmentaOrchestrator`, personality-driven tool selection logic, etc.) directly poll the `EmotionSystem` for its fine-grained emotional scores (e.g., specific valence/arousal values) and have complex conditional logic based on these raw scores, the system can become over-sensitive.
+    *   Minor, perhaps insignificant, fluctuations in emotion scores could trigger widespread behavioral changes.
+    *   Changes to the internal representation or calculation of emotions within `EmotionSystem` could break many consumer modules.
+
+*   **Recommendations:**
+    1.  **Event-Driven Notifications (Internal Event Bus):**
+        *   The `EmotionSystem` could publish significant, qualitative emotion shift events to an internal event bus. Examples:
+            *   `UserMoodDetectedEvent(mood_type="frustration", intensity="high", session_id="...")`
+            *   `AIInternalStateShiftEvent(new_dominant_emotion="calm", previous_emotion="anxious")`
+            *   `HighIntensityEmotionTriggeredEvent(emotion="anger", trigger_context="...")`
+        *   Modules that need to react to *significant changes* or specific emotional events would subscribe to these events rather than constantly polling or interpreting raw scores.
+        *   *Benefit:* Reduces direct dependencies, modules only react when necessary, `EmotionSystem` internals are better encapsulated.
+    2.  **Abstracted Emotion State Queries:**
+        *   For modules that do need to query the current emotional state, `EmotionSystem` could provide a higher-level, more abstract API. Instead of (or in addition to) raw scores, it might offer methods like:
+            *   `getCurrentEmotionalToneCategory()` returning "positive_calm", "negative_aroused", "neutral", "empathetic", etc.
+            *   `isCurrentEmotionIntensity(level="high")`
+        *   *Benefit:* Consumers depend on a more stable, abstracted interface, making them less sensitive to minor score fluctuations or internal changes in how scores are derived.
+    3.  **Emotion Context Object:**
+        *   When `DialogueManager` or `FragmentaOrchestrator` needs to pass emotional context to sub-modules (like LLMs for response generation), they could pass a summarized `EmotionContext` object rather than raw scores, derived from the `EmotionSystem`.
+        *   *Benefit:* Standardizes how emotional context is passed and used.
+
+### 2.2. Learning System & Knowledge Dissemination
+
+*   **Current/Potential Concern:**
+    *   When the `LearningManager` stores new facts (from user input or HSP) or when the `ContentAnalyzerModule` updates its knowledge graph (KG), how do other modules like `DialogueManager` (for improved contextual responses) or `FragmentaOrchestrator` (for better task strategies) become aware of and utilize this new knowledge in a timely and efficient manner?
+    *   Direct calls from the learning components to update other modules would create tight coupling. Shared mutable state for the KG could lead to concurrency issues if not carefully managed.
+
+*   **Recommendations:**
+    1.  **Knowledge Repository (HAM as the Source of Truth):**
+        *   Reinforce the role of `HAMMemoryManager` as the central, canonical store for learned facts and potentially for persisted/shared versions of the knowledge graph.
+        *   Modules requiring learned information should primarily query HAM.
+        *   *Benefit:* HAM already provides a degree of decoupling for persisted knowledge.
+    2.  **Internal Event Bus for Knowledge Updates:**
+        *   `LearningManager` or `ContentAnalyzerModule` can publish events upon significant knowledge updates:
+            *   `NewFactStoredEvent(fact_id="...", fact_type="...", source="...")`
+            *   `KnowledgeGraphUpdatedEvent(session_id="...", changes_summary="...")`
+        *   Modules like `DialogueManager` could subscribe to these events. The event might contain a summary or just be a notification to re-query HAM or its own cached/derived view of the knowledge for relevant updates.
+        *   *Benefit:* Proactive notification without direct coupling; allows consumers to decide if/how to react.
+    3.  **Cache Invalidation / Smart Caching for KGs:**
+        *   If `DialogueManager` or other modules maintain an in-memory version or cache of the KG for performance, `KnowledgeGraphUpdatedEvent` can act as a cache invalidation signal.
+        *   *Benefit:* Balances performance with data freshness.
+
+### 2.3. Fragmenta Orchestrator - Sub-Module Interactions
+
+*   **Current/Potential Concern:**
+    *   The `FragmentaOrchestrator` needs to dispatch tasks to various components (LLMs, tools, other AI modules). If it's coded to interact with concrete implementations directly, it becomes brittle and hard to extend with new types of tools or models.
+    *   The `Fragmenta_design_spec.md` is ambitious, and a tightly coupled implementation would be very complex to manage.
+
+*   **Recommendations:**
+    1.  **Abstract Interfaces / Adapters for Dispatched Services:**
+        *   Define abstract base classes or protocols (interfaces) for common categories of services Fragmenta uses, e.g.:
+            *   `ISummarizationService { summarize(text: str) -> str }`
+            *   `IDataProcessingTool { process(data: Any, params: Dict) -> Any }`
+            *   `IQueryableKnowledgeSource { query(query_params: Dict) -> List[Dict] }`
+        *   Concrete tools, LLM interfaces, or other modules would then implement these interfaces, possibly via Adapter patterns if their native APIs differ.
+        *   Fragmenta would be coded against these abstract interfaces.
+        *   *Benefit:* Fragmenta can orchestrate diverse components uniformly; new tools/models can be integrated by providing a new adapter/implementation of an interface.
+    2.  **Standardized Task/Result Data Structures for Sub-Tasks:**
+        *   Use common `TypedDicts` (from `shared/types/common_types.py`) for defining the structure of requests sent to sub-modules and the results received from them.
+        *   *Benefit:* Clear contracts for sub-task interactions.
+    3.  **Strategy Pattern for Processing Flows:**
+        *   The `_determine_processing_strategy` method in Fragmenta could return a "Strategy" object. This object would encapsulate the specific sequence of steps (chunking, dispatching to abstracted services, merging) for a given task type.
+        *   *Benefit:* Makes strategies pluggable and easier to manage than large conditional blocks.
+
+### 2.4. Configuration Management Access
+
+*   **Current/Potential Concern:**
+    *   If various modules independently access and parse configuration files (e.g., `system_config.yaml`, `api_keys.yaml`) or navigate complex configuration dictionaries, they become highly sensitive to changes in the config file structure or key names.
+
+*   **Recommendations:**
+    1.  **Centralized Configuration Manager/Provider (Facade):**
+        *   Implement or ensure a dedicated `ConfigManager` class is used project-wide.
+        *   This manager loads all relevant configuration sources (files, environment variables) at startup.
+        *   It provides specific getter methods for modules to request the configuration values they need, e.g., `config_manager.get_llm_default_model()`, `config_manager.get_hsp_broker_address()`, `config_manager.get_learning_threshold("min_fact_confidence_to_store")`.
+        *   Modules are injected with or have access to this `ConfigManager` instance.
+        *   *Benefit:* Knowledge of the configuration structure is centralized. Modules ask for what they need semantically. Config file structure can change with minimal impact on consuming modules, as long as the `ConfigManager`'s interface remains stable or is versioned. (The project seems to have groundwork for this via `configs/` and how `LLMInterface` takes config, but ensuring consistent use is key).
+
+### 2.5. Internal HSP Interactions (Simplification Facade)
+
+*   **Current/Potential Concern:**
+    *   Core AI modules (e.g., `LearningManager` publishing a newly derived fact, `DialogueManager` needing to request a capability from a peer) might need to engage in verbose HSP envelope construction or direct MQTT topic management via `HSPConnector`. This can be complex and couples them to HSP specifics.
+
+*   **Recommendations:**
+    1.  **Higher-Level Methods in `HSPConnector` or a New `HSPServiceFacade`:**
+        *   Introduce simplified methods for common internal use-cases, e.g.:
+            *   `hsp_connector.publish_fact_to_network(fact_payload: HSPFactPayload, target_topic_category: str = "general_facts")`
+            *   `hsp_connector.request_capability_from_peer(capability_name: str, parameters: Dict, timeout: Optional[int] = None) -> Optional[HSPTaskResultPayload]`
+        *   This facade/method would handle:
+            *   Building the full `HSPMessageEnvelope`.
+            *   Determining appropriate topics based on conventions or service discovery.
+            *   Managing correlation IDs for request/response patterns internally if needed for simplification.
+        *   *Benefit:* Internal modules can interact with the HSP network at a higher level of abstraction, focusing on *what* they want to achieve rather than *how* HSP messages are precisely structured and routed. `HSPConnector` remains the low-level handler, but offers simpler entry points.
+
+## 3. General Decoupling Best Practices
+
+Beyond specific areas, adhering to general software design principles will aid decoupling:
+
+*   **Law of Demeter (Principle of Least Knowledge):** A module should not "reach through" its direct collaborators to access distant parts of the system. Talk only to your immediate friends.
+*   **Interface Segregation Principle:** Clients should not be forced to depend on interfaces they do not use. Prefer smaller, more specific interfaces.
+*   **Dependency Inversion Principle:** High-level modules should not depend on low-level modules. Both should depend on abstractions (e.g., interfaces, abstract base classes). Abstractions should not depend on details. Details should depend on abstractions.
+*   **Clear Data Contracts:** Continue rigorous use of `TypedDict` (or Pydantic if validation becomes critical) for all data passed between components.
+*   **Single Responsibility Principle:** Each module or class should have one primary responsibility. This naturally leads to more focused and less coupled components.
+
+## 4. Conclusion
+
+A proactive and continuous approach to decoupling is essential for the long-term health, scalability, and maintainability of the Unified-AI-Project. By identifying areas of tight coupling or potential over-sensitization and strategically applying appropriate decoupling patterns (like event buses, facades, abstract interfaces, and centralized managers for cross-cutting concerns), the project can evolve more robustly. The recommendations above provide starting points for architectural discussions and potential refactoring efforts.


### PR DESCRIPTION
Created docs/PROJECT_CONTENT_ORGANIZATION.md to provide a structured overview of the project's directories and key files, categorized by their purpose.

This document aims to help in navigating the project and understanding where different functionalities reside.