### PR TITLE
Feat: Define LISCacheInterface and HAMLISCache conceptual outline

### DIFF
--- a/src/core_ai/lis/__init__.py
+++ b/src/core_ai/lis/__init__.py
@@ -1,0 +1,17 @@
+# src/core_ai/lis/__init__.py
+"""
+LIS (Linguistic Immune System) Sub-package.
+
+This sub-package will contain modules related to the Linguistic Immune System,
+responsible for detecting, diagnosing, and responding to semantic anomalies,
+as well as facilitating error-driven linguistic evolution.
+"""
+
+# Expose key classes or interfaces for easier import if desired.
+# For example, once HAMLISCache or other implementations exist:
+# from .lis_cache_interface import LISCacheInterface, HAMLISCache
+# from .err_introspector import ERR_INTROSPECTOR # If it becomes a class
+
+# For now, just making it a package.
+VERSION = "0.0.1" # Conceptual version for this sub-package
+print(f"core_ai.lis package initialized (version {VERSION})")

--- a/src/core_ai/lis/lis_cache_interface.py
+++ b/src/core_ai/lis/lis_cache_interface.py
@@ -1,0 +1,448 @@
+# src/core_ai/lis/lis_cache_interface.py
+"""
+Defines the interface for the Linguistic Immune System (LIS) Cache,
+also known as the IMMUNO-NARRATIVE CACHE.
+
+This cache is responsible for storing, retrieving, and querying records of
+linguistic/semantic incidents, their analyses, interventions, and outcomes.
+It forms the memory component of the LIS, supporting its learning and
+adaptive capabilities.
+"""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Dict, Any
+
+# Assuming types will be imported from shared.types
+from shared.types.common_types import (
+    LIS_IncidentRecord,
+    LIS_SemanticAnomalyDetectedEvent,
+    LIS_AnomalyType,
+    LIS_InterventionReport # Added LIS_InterventionReport
+)
+
+# Placeholder for Antibody type, will be refined later
+# Using a more specific name for clarity if it's intended to be an object/dict
+NarrativeAntibodyObject = Dict[str, Any]
+
+
+class LISCacheInterface(ABC):
+    """
+    Abstract Base Class defining the interface for the IMMUNO-NARRATIVE CACHE.
+    Implementations of this interface will provide concrete storage and
+    retrieval mechanisms for LIS incident data.
+    """
+
+    @abstractmethod
+    def store_incident(self, incident_record: LIS_IncidentRecord) -> bool:
+        """
+        Stores a new LIS incident record in the cache.
+
+        Args:
+            incident_record (LIS_IncidentRecord): The complete record of the incident.
+
+        Returns:
+            bool: True if storage was successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def get_incident_by_id(self, incident_id: str) -> Optional[LIS_IncidentRecord]:
+        """
+        Retrieves a specific LIS incident record by its unique ID.
+
+        Args:
+            incident_id (str): The ID of the incident to retrieve.
+
+        Returns:
+            Optional[LIS_IncidentRecord]: The incident record if found, else None.
+        """
+        pass
+
+    @abstractmethod
+    def query_incidents(self,
+                        anomaly_type: Optional[LIS_AnomalyType] = None,
+                        min_severity: Optional[float] = None,
+                        status: Optional[str] = None, # Should use a Literal type for status later (e.g., LIS_IncidentStatus)
+                        tags: Optional[List[str]] = None,
+                        time_window_hours: Optional[int] = None,
+                        limit: int = 10,
+                        sort_by_timestamp_desc: bool = True
+                        ) -> List[LIS_IncidentRecord]:
+        """
+        Queries the cache for LIS incident records based on various criteria.
+
+        Args:
+            anomaly_type (Optional[LIS_AnomalyType]): Filter by type of anomaly.
+            min_severity (Optional[float]): Filter by minimum severity score (0.0-1.0).
+            status (Optional[str]): Filter by incident status (e.g., "OPEN", "CLOSED_RESOLVED").
+                                    Consider defining an LIS_IncidentStatus Literal type.
+            tags (Optional[List[str]]): Filter by associated tags.
+            time_window_hours (Optional[int]): Look back N hours from now.
+            limit (int): Maximum number of records to return.
+            sort_by_timestamp_desc (bool): Whether to sort results by timestamp descending (most recent first).
+
+
+        Returns:
+            List[LIS_IncidentRecord]: A list of matching incident records.
+        """
+        pass
+
+    @abstractmethod
+    def find_related_incidents(self,
+                               event_details: LIS_SemanticAnomalyDetectedEvent,
+                               top_n: int = 3
+                               ) -> List[LIS_IncidentRecord]:
+        """
+        Finds past incidents that are semantically similar or related to a new
+        detected event. Used to find historical context or relevant "antibodies".
+
+        Args:
+            event_details (LIS_SemanticAnomalyDetectedEvent): Details of the new event.
+            top_n (int): Maximum number of related incidents to return.
+
+        Returns:
+            List[LIS_IncidentRecord]: A list of related past incidents.
+        """
+        pass
+
+    @abstractmethod
+    def get_learned_antibodies(self,
+                               for_anomaly_type: Optional[LIS_AnomalyType] = None,
+                               min_effectiveness: Optional[float] = None,
+                               limit: int = 5
+                               ) -> List[NarrativeAntibodyObject]:
+        """
+        Retrieves "narrative antibodies" (learned successful response patterns or strategies)
+        from the cache.
+
+        Args:
+            for_anomaly_type (Optional[LIS_AnomalyType]): Filter antibodies relevant to a specific anomaly type.
+            min_effectiveness (Optional[float]): Filter by minimum effectiveness score of the antibody.
+            limit (int): Maximum number of antibodies to return.
+
+        Returns:
+            List[NarrativeAntibodyObject]: A list of learned antibodies.
+                                           The structure of NarrativeAntibodyObject needs to be defined more concretely.
+        """
+        pass
+
+    @abstractmethod
+    def update_incident_status(self,
+                               incident_id: str,
+                               new_status: str, # Should use an LIS_IncidentStatus Literal type later
+                               notes: Optional[str] = None,
+                               intervention_report: Optional[LIS_InterventionReport] = None
+                               ) -> bool:
+        """
+        Updates the status and optionally adds notes or an intervention report
+        to an existing LIS incident record.
+
+        Args:
+            incident_id (str): The ID of the incident to update.
+            new_status (str): The new status for the incident.
+            notes (Optional[str]): Additional notes to append or set.
+            intervention_report (Optional[LIS_InterventionReport]): An intervention report to add to the incident's list.
+
+        Returns:
+            bool: True if the update was successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def add_antibody(self, antibody: NarrativeAntibodyObject) -> bool:
+        """
+        Stores a new "narrative antibody" into the cache.
+
+        Args:
+            antibody (NarrativeAntibodyObject): The antibody object to store.
+                                               Its structure needs to be defined.
+        Returns:
+            bool: True if successful.
+        """
+        pass
+
+
+# --- Concrete Implementation (Conceptual Outline & Design Notes) ---
+
+# Import HAMMemoryManager for type hinting in the concrete implementation.
+# This assumes HAMMemoryManager is accessible, e.g., from core_ai.memory.ham_memory_manager
+# from core_ai.memory.ham_memory_manager import HAMMemoryManager
+# For now, using Any to avoid import error if HAMMemoryManager is not directly visible without full project context.
+from core_ai.memory.ham_memory_manager import HAMMemoryManager # Assuming this path is correct relative to project structure
+
+
+class HAMLISCache(LISCacheInterface):
+    """
+    A concrete implementation of the LISCacheInterface that uses the
+    Hierarchical Associative Memory (HAM) for persistence.
+
+    Design Considerations:
+    - Each LIS_IncidentRecord and NarrativeAntibodyObject will be stored as a
+      distinct entry in HAM.
+    - A specific `data_type` prefix (e.g., "lis_incident_v01_", "lis_antibody_v01_")
+      will be used for these HAM entries to allow for targeted querying.
+    - Key queryable fields from these objects (e.g., anomaly_type, status, tags for incidents;
+      anomaly_type, effectiveness for antibodies) will be duplicated or extracted
+      into the HAM metadata of the corresponding entry to leverage HAM's
+      metadata-based querying capabilities.
+    - The full LIS_IncidentRecord or NarrativeAntibodyObject will be stored as the
+      main content (e.g., serialized to JSON if HAM stores strings, or as dict if HAM handles complex objects)
+      of the HAM entry.
+    - Updates to incidents (like status changes or adding reports) might involve
+      retrieving the HAM entry, modifying its content/metadata, and re-storing it.
+      If HAM entries are immutable by their primary key (mem_id), this would mean storing
+      a new version and an application-level mechanism to point to the latest version
+      (or HAM itself might support versioning/superseding).
+      A simpler approach for HAM if it supports metadata updates on existing records
+      would be to update metadata fields like 'lis_status' or append to a 'lis_notes_log' field.
+      Adding an intervention report to an existing incident might require fetching, updating the list, and re-storing.
+    - Semantic similarity for `find_related_incidents` is complex. It would likely require
+      storing embeddings or feature vectors (derived from `LIS_SemanticAnomalyDetectedEvent` details)
+      within HAM metadata or content, and HAM supporting similarity queries on those.
+      This is an advanced feature beyond initial HAM capabilities.
+    """
+    def __init__(self, ham_manager: HAMMemoryManager):
+        """
+        Initializes the HAMLISCache with a HAMMemoryManager instance.
+
+        Args:
+            ham_manager (HAMMemoryManager): The HAM instance to use for storage.
+        """
+        self.ham_manager = ham_manager
+        self.incident_data_type_prefix = "lis_incident_v01_" # versioned prefix
+        self.antibody_data_type_prefix = "lis_antibody_v01_"
+        print(f"HAMLISCache initialized, using HAM instance: {type(ham_manager).__name__}")
+
+    def store_incident(self, incident_record: LIS_IncidentRecord) -> bool:
+        """
+        Stores LIS_IncidentRecord in HAM.
+        Key queryable fields are stored in HAM metadata.
+        The LIS_IncidentRecord itself is stored as raw_data (likely serialized to JSON string).
+        """
+        # Example data_type construction:
+        # anomaly_event_type = incident_record.get('anomaly_event', {}).get('anomaly_type', 'UNKNOWN_ANOMALY')
+        # data_type = f"{self.incident_data_type_prefix}{anomaly_event_type}"
+
+        # Example metadata extraction for HAM:
+        # ham_metadata = {
+        #     "lis_incident_id": incident_record.get("incident_id"), # Primary key for LIS
+        #     "lis_anomaly_type": anomaly_event_type,
+        #     "lis_severity": incident_record.get("anomaly_event", {}).get("severity_score"),
+        #     "lis_status": incident_record.get("status"),
+        #     "lis_tags": incident_record.get("tags", []),
+        #     "timestamp_logged": incident_record.get("timestamp_logged") # For HAM's own sorting/querying
+        # }
+
+        # # Serialize the incident_record for storage if HAM expects string/bytes.
+        # try:
+        #     serialized_record = json.dumps(incident_record)
+        # except TypeError as e:
+        #     print(f"Error serializing incident_record: {e}")
+        #     return False
+
+        # mem_id = self.ham_manager.store_experience(
+        #     raw_data=serialized_record, # Store serialized record
+        #     data_type=data_type,
+        #     metadata=ham_metadata
+        # )
+        # return bool(mem_id)
+        print(f"Conceptual: HAMLISCache.store_incident called for {incident_record.get('incident_id')}")
+        # Placeholder: Full implementation requires HAMMemoryManager integration.
+        return False # Placeholder
+
+    def get_incident_by_id(self, incident_id: str) -> Optional[LIS_IncidentRecord]:
+        """
+        Retrieves an LIS_IncidentRecord from HAM by its 'lis_incident_id' metadata field.
+        """
+        # ham_records_results = self.ham_manager.query_core_memory(
+        #     metadata_filters={"lis_incident_id": incident_id},
+        #     data_type_filter=self.incident_data_type_prefix, # Query across all LIS incident types
+        #     limit=1
+        # )
+        # if ham_records_results:
+        #     recalled_ham_entry = ham_records_results[0]
+        #     # HAMRecallResult has 'rehydrated_gist'. This should be the serialized LIS_IncidentRecord.
+        #     serialized_record = recalled_ham_entry.get("rehydrated_gist")
+        #     if isinstance(serialized_record, str):
+        #         try:
+        #             incident_data = json.loads(serialized_record)
+        #             return incident_data # type: ignore # Assuming structure matches LIS_IncidentRecord
+        #         except json.JSONDecodeError as e:
+        #             print(f"Error deserializing LIS incident record {incident_id} from HAM: {e}")
+        #             return None
+        print(f"Conceptual: HAMLISCache.get_incident_by_id called for {incident_id}")
+        # Placeholder
+        return None
+
+    def query_incidents(self,
+                        anomaly_type: Optional[LIS_AnomalyType] = None,
+                        min_severity: Optional[float] = None,
+                        status: Optional[str] = None,
+                        tags: Optional[List[str]] = None,
+                        time_window_hours: Optional[int] = None,
+                        limit: int = 10,
+                        sort_by_timestamp_desc: bool = True
+                        ) -> List[LIS_IncidentRecord]:
+        """
+        Queries HAM for LIS_IncidentRecords.
+        Builds metadata_filters for HAM query.
+        Post-filtering may be needed for severity and time_window if not directly supported by HAM query.
+        """
+        # metadata_filters = {}
+        # if anomaly_type: metadata_filters["lis_anomaly_type"] = anomaly_type
+        # if status: metadata_filters["lis_status"] = status
+        # if tags: metadata_filters["lis_tags"] = tags # HAM needs to support list containment or exact match
+
+        # # HAM query for timestamp range for time_window_hours.
+        # # HAM query for severity >= min_severity.
+
+        # ham_results = self.ham_manager.query_core_memory(
+        #     metadata_filters=metadata_filters,
+        #     data_type_filter=self.incident_data_type_prefix,
+        #     limit=limit * 2, # Fetch more for potential post-filtering
+        #     # sort_by_timestamp_desc needs to be supported by HAM or done in post-processing
+        # )
+        #
+        # incidents = []
+        # for item in ham_results:
+        #     serialized_record = item.get("rehydrated_gist")
+        #     if isinstance(serialized_record, str):
+        #         try:
+        #             record = json.loads(serialized_record)
+        #             # TODO: Add post-filtering for min_severity, time_window_hours if not done by HAM
+        #             incidents.append(record) # type: ignore
+        #         except json.JSONDecodeError:
+        #             continue # Skip malformed records
+        #
+        # # TODO: if not sorted by HAM, sort `incidents` by timestamp_logged (desc if sort_by_timestamp_desc)
+        # return incidents[:limit]
+        print(f"Conceptual: HAMLISCache.query_incidents called.")
+        # Placeholder
+        return []
+
+    def find_related_incidents(self,
+                               event_details: LIS_SemanticAnomalyDetectedEvent,
+                               top_n: int = 3
+                               ) -> List[LIS_IncidentRecord]:
+        """
+        Conceptual:
+        - Extract features/embeddings from event_details.problematic_output_segment or context.
+        - Query HAM for incidents with similar features/embeddings.
+        - This is an advanced function requiring significant HAM enhancements for similarity search.
+        """
+        print(f"Conceptual: HAMLISCache.find_related_incidents for event {event_details.get('anomaly_id')}")
+        # Placeholder
+        return []
+
+    def get_learned_antibodies(self,
+                               for_anomaly_type: Optional[LIS_AnomalyType] = None,
+                               min_effectiveness: Optional[float] = None,
+                               limit: int = 5
+                               ) -> List[NarrativeAntibodyObject]:
+        """
+        Queries HAM for NarrativeAntibodyObjects using the antibody_data_type_prefix.
+        """
+        # metadata_filters = {}
+        # if for_anomaly_type: metadata_filters["antibody_applies_to_anomaly"] = for_anomaly_type
+        # # min_effectiveness might require post-filtering if HAM doesn't support range query on this field
+        #
+        # ham_results = self.ham_manager.query_core_memory(
+        #     metadata_filters=metadata_filters,
+        #     data_type_filter=self.antibody_data_type_prefix,
+        #     limit=limit * 2
+        # )
+        # antibodies = []
+        # for item in ham_results:
+        #     serialized_antibody = item.get("rehydrated_gist")
+        #     if isinstance(serialized_antibody, str):
+        #         try:
+        #             antibody = json.loads(serialized_antibody)
+        #             # TODO: Post-filter for min_effectiveness
+        #             antibodies.append(antibody)
+        #         except json.JSONDecodeError:
+        #             continue
+        # return antibodies[:limit]
+        print(f"Conceptual: HAMLISCache.get_learned_antibodies called.")
+        # Placeholder
+        return []
+
+    def update_incident_status(self,
+                               incident_id: str,
+                               new_status: str,
+                               notes: Optional[str] = None,
+                               intervention_report: Optional[LIS_InterventionReport] = None
+                               ) -> bool:
+        """
+        Updates an existing LIS_IncidentRecord in HAM.
+        Requires HAM to support fetching by a custom metadata ID ('lis_incident_id') and
+        then updating the record (either by replacing or by specific metadata update methods).
+        """
+        # 1. Fetch the HAM entry/entries matching `lis_incident_id`.
+        #    (HAM's query_core_memory returns a list; assume only one for a unique ID).
+        #    ham_entries = self.ham_manager.query_core_memory(metadata_filters={"lis_incident_id": incident_id}, limit=1, data_type_filter=self.incident_data_type_prefix)
+        #    if not ham_entries: return False
+        #    ham_record_id_to_update = ham_entries[0].get("id") # This is HAM's internal mem_id
+        #    serialized_record = ham_entries[0].get("rehydrated_gist")
+        #
+        #    if not isinstance(serialized_record, str): return False
+        #    try:
+        #        record_content: LIS_IncidentRecord = json.loads(serialized_record) # type: ignore
+        #    except json.JSONDecodeError:
+        #        return False
+        #
+        # 2. Modify the record_content:
+        #    record_content["status"] = new_status
+        #    if notes:
+        #        record_content["notes"] = f"{record_content.get('notes', '')}\n[{datetime.now().isoformat()}] {notes}".strip()
+        #    if intervention_report:
+        #        if "intervention_reports" not in record_content or record_content["intervention_reports"] is None:
+        #            record_content["intervention_reports"] = []
+        #        record_content["intervention_reports"].append(intervention_report)
+        #    record_content["timestamp_logged"] = datetime.now().isoformat() # Update last modified time
+        #
+        # 3. Re-store/Update in HAM:
+        #    # Option A: If HAM supports updating metadata of an existing record by its ham_record_id
+        #    # updated_metadata = {"lis_status": new_status, "timestamp_logged": record_content["timestamp_logged"]}
+        #    # success_meta = self.ham_manager.update_metadata(ham_record_id_to_update, updated_metadata)
+        #    # To update full content, HAM would need update_experience(ham_id, new_content_dict)
+        #    # success_content = self.ham_manager.update_experience_content(ham_record_id_to_update, record_content)
+        #    # return success_meta and success_content (or however HAM handles it)
+        #
+        #    # Option B: If HAM is append-only or updates by replacing (store new, mark old superseded)
+        #    # This is simpler if HAM doesn't have fine-grained updates.
+        #    # New incident_id for the updated record IS NOT GOOD. We need to update the original.
+        #    # This implies HAM needs a way to update a record by a custom key like "lis_incident_id"
+        #    # or by its internal mem_id. For now, let's assume a conceptual update.
+        #    # For true update, store_incident would need an `update_if_exists` flag or similar.
+        #    # This is a placeholder for a more robust HAM update mechanism.
+        print(f"Conceptual: HAMLISCache.update_incident_status for {incident_id} to {new_status}")
+        # Placeholder
+        return False
+
+    def add_antibody(self, antibody: NarrativeAntibodyObject) -> bool:
+        """
+        Stores a NarrativeAntibodyObject in HAM.
+        """
+        # antibody_id = antibody.get("antibody_id", str(uuid.uuid4()))
+        # data_type = f"{self.antibody_data_type_prefix}{antibody.get('for_anomaly_type','GENERIC_ANTIBODY')}"
+        # ham_metadata = {
+        #     "lis_antibody_id": antibody_id,
+        #     "lis_antibody_for_anomaly_type": antibody.get("for_anomaly_type"),
+        #     "lis_antibody_effectiveness": antibody.get("effectiveness_score"),
+        #     "timestamp_created": antibody.get("timestamp_created", datetime.now().isoformat())
+        # }
+        # try:
+        #     serialized_antibody = json.dumps(antibody)
+        # except TypeError as e:
+        #     print(f"Error serializing antibody: {e}")
+        #     return False
+        #
+        # mem_id = self.ham_manager.store_experience(
+        #     raw_data=serialized_antibody,
+        #     data_type=data_type,
+        #     metadata=ham_metadata
+        # )
+        # return bool(mem_id)
+        print(f"Conceptual: HAMLISCache.add_antibody called.")
+        # Placeholder
+        return False


### PR DESCRIPTION
- Create `src/core_ai/lis/` directory and `__init__.py` to establish the LIS sub-package.
- Create `src/core_ai/lis/lis_cache_interface.py`.
- Define `LISCacheInterface(ABC)` with abstract methods for:
    - `store_incident`
    - `get_incident_by_id`
    - `query_incidents`
    - `find_related_incidents`
    - `get_learned_antibodies`
    - `update_incident_status`
    - `add_antibody`
- Add `HAMLISCache(LISCacheInterface)` class skeleton.
    - Include detailed comments outlining design considerations for a HAM-based implementation, covering data storage, metadata usage for querying, and handling of updates. Full implementation of HAMLISCache methods is deferred.

This commit establishes the interface for the IMMUNO-NARRATIVE CACHE and provides initial design thoughts for its HAM-based persistence, paving the way for further LIS component development.