### PR TITLE
Feat: Implement basic HAMLISCache store and get methods with tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ requests
 # google-generativeai
 python-dotenv
 PyYAML
+typing-extensions # For Required, NotRequired, etc.
 # openai
 # langchain
 

--- a/src/core_ai/memory/ham_memory_manager.py
+++ b/src/core_ai/memory/ham_memory_manager.py
@@ -8,7 +8,7 @@ from cryptography.fernet import Fernet, InvalidToken
 import hashlib
 import asyncio # Added for asyncio.to_thread
 from typing import Optional, List, Dict, Any, Tuple, Union # Added Union for recall_gist return
-from shared.types.common_types import DialogueMemoryEntryMetadata, HAMDataPackageInternal, HAMRecallResult # Import new types
+from src.shared.types.common_types import DialogueMemoryEntryMetadata, HAMDataPackageInternal, HAMRecallResult # Import new types, changed to src.
 
 # Placeholder for actual stopword list and NLP tools if not available
 try:

--- a/tests/core_ai/lis/__init__.py
+++ b/tests/core_ai/lis/__init__.py
@@ -1,0 +1,2 @@
+# tests/core_ai/lis/__init__.py
+# This file makes Python treat the directory tests/core_ai/lis as a package.

--- a/tests/core_ai/lis/test_ham_lis_cache.py
+++ b/tests/core_ai/lis/test_ham_lis_cache.py
@@ -1,0 +1,251 @@
+# tests/core_ai/lis/test_ham_lis_cache.py
+import unittest
+import json
+from typing import Dict, Any, Optional, List, cast
+from datetime import datetime
+
+# Adjust imports based on actual project structure
+# Assuming 'src' is effectively a top-level package for test execution context
+from src.core_ai.lis.lis_cache_interface import (
+    HAMLISCache, LISCacheInterface,
+    # Import constants defined in lis_cache_interface.py
+    HAM_META_LIS_OBJECT_ID,
+    HAM_META_LIS_ANOMALY_TYPE,
+    HAM_META_LIS_STATUS,
+    HAM_META_LIS_TAGS,
+    HAM_META_TIMESTAMP_LOGGED,
+    LIS_INCIDENT_DATA_TYPE_PREFIX
+)
+from src.core_ai.memory.ham_memory_manager import HAMMemoryManager, HAMRecallResult
+from src.shared.types.common_types import (
+    LIS_IncidentRecord,
+    LIS_SemanticAnomalyDetectedEvent,
+    LIS_AnomalyType,
+    LIS_InterventionReport,
+    LIS_InterventionOutcome
+    # Constants are now imported from lis_cache_interface directly
+)
+
+class MockHAMMemoryManager(HAMMemoryManager):
+    """
+    A mock implementation of HAMMemoryManager for testing HAMLISCache.
+    This mock stores experiences in an in-memory dictionary.
+    It needs to simulate how store_experience and query_core_memory work,
+    particularly regarding raw_data (JSON string) and metadata.
+    """
+    def __init__(self, core_storage_filename: str = "mock_ham_lis_test.json"):
+        # super().__init__(core_storage_filename) # Avoid actual file operations
+        self.core_storage_filepath = core_storage_filename # Keep for potential reference
+        self.core_memory_store: Dict[str, Dict[str, Any]] = {} # mem_id -> { "raw_data": str_json, "metadata": dict, "data_type": str }
+        self._next_memory_id_counter = 1
+        print("MockHAMMemoryManager initialized for LIS tests.")
+
+    def _generate_memory_id(self) -> str:
+        mem_id = f"mock_mem_{self._next_memory_id_counter:06d}"
+        self._next_memory_id_counter += 1
+        return mem_id
+
+    def store_experience(self, raw_data: Any, data_type: str, metadata: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        if not isinstance(raw_data, str): # HAMLISCache should pass a JSON string
+            print(f"MockHAM: Warning - store_experience expected str raw_data, got {type(raw_data)}")
+            # Forcing it to string for mock storage consistency if it's a dict
+            if isinstance(raw_data, dict):
+                try:
+                    raw_data = json.dumps(raw_data)
+                except TypeError:
+                    return None # Cannot serialize
+            else:
+                return None # Unexpected type
+
+        mem_id = self._generate_memory_id()
+        self.core_memory_store[mem_id] = {
+            "raw_data": raw_data, # Should be a JSON string from HAMLISCache
+            "data_type": data_type,
+            "metadata": metadata or {}
+        }
+        # print(f"MockHAM: Stored '{mem_id}' - type: '{data_type}', meta: {metadata}")
+        return mem_id
+
+    def query_core_memory(self,
+                          metadata_filters: Optional[Dict[str, Any]] = None,
+                          data_type_filter: Optional[str] = None,
+                          date_range: Optional[tuple[datetime, datetime]] = None, # Not used in these tests yet
+                          limit: int = 10,
+                          search_in_content: Optional[str] = None, # Not used
+                          sort_by_timestamp_desc: bool = True # Not strictly implemented in mock sorting
+                          ) -> List[HAMRecallResult]:
+        results: List[HAMRecallResult] = []
+
+        # print(f"MockHAM: Querying with filters: {metadata_filters}, type_filter: {data_type_filter}")
+
+        for mem_id, entry in self.core_memory_store.items():
+            match = True
+            if data_type_filter and not entry["data_type"].startswith(data_type_filter):
+                match = False
+
+            if match and metadata_filters:
+                for key, value in metadata_filters.items():
+                    if entry["metadata"].get(key) != value:
+                        match = False
+                        break
+
+            if match:
+                # Construct HAMRecallResult. 'rehydrated_gist' for HAMLISCache is the stored JSON string.
+                # 'timestamp' and 'data_type' in HAMRecallResult come from the stored entry.
+                recall_result: HAMRecallResult = { # type: ignore
+                    "id": mem_id,
+                    "timestamp": entry["metadata"].get(HAM_META_TIMESTAMP_LOGGED, entry["metadata"].get("timestamp_logged", "1970-01-01T00:00:00Z")), # Use specific or fallback
+                    "data_type": entry["data_type"],
+                    "rehydrated_gist": entry["raw_data"], # This is the JSON string
+                    "metadata": entry["metadata"]
+                }
+                results.append(recall_result)
+
+        # Simple sort by mem_id for some consistency if not by timestamp
+        results.sort(key=lambda x: x["id"], reverse=sort_by_timestamp_desc)
+        return results[:limit]
+
+    def recall_gist(self, memory_id: str) -> Optional[HAMRecallResult]:
+        # This method might not be directly used by HAMLISCache.get_incident_by_id if query_core_memory is sufficient
+        entry = self.core_memory_store.get(memory_id)
+        if entry:
+            recall_result: HAMRecallResult = { # type: ignore
+                "id": memory_id,
+                "timestamp": entry["metadata"].get(HAM_META_TIMESTAMP_LOGGED, "1970-01-01T00:00:00Z"),
+                "data_type": entry["data_type"],
+                "rehydrated_gist": entry["raw_data"],
+                "metadata": entry["metadata"]
+            }
+            return recall_result
+        return None
+
+    def clear_memory(self):
+        self.core_memory_store = {}
+        self._next_memory_id_counter = 1
+
+
+class TestHAMLISCache(unittest.TestCase):
+    def setUp(self):
+        self.mock_ham_manager = MockHAMMemoryManager()
+        self.lis_cache: LISCacheInterface = HAMLISCache(ham_manager=self.mock_ham_manager) # type: ignore
+
+    def tearDown(self):
+        self.mock_ham_manager.clear_memory()
+
+    def _create_sample_incident_record(self, incident_id: str, anomaly_type: LIS_AnomalyType = "RHYTHM_BREAK", status: str = "OPEN") -> LIS_IncidentRecord:
+        # Helper to create a valid LIS_IncidentRecord for tests
+        timestamp_now = datetime.now().isoformat()
+        event: LIS_SemanticAnomalyDetectedEvent = { # type: ignore
+            "anomaly_id": f"anomaly_{incident_id}",
+            "timestamp": timestamp_now,
+            "anomaly_type": anomaly_type,
+            "severity_score": 0.7,
+            "problematic_output_segment": "This is a test segment.",
+            "current_context_snapshot": {"dialogue_history": [{"speaker": "user", "text": "Hello"}]},
+            "detector_component": "TestDetector"
+        }
+        record: LIS_IncidentRecord = { # type: ignore
+            "incident_id": incident_id,
+            "timestamp_logged": timestamp_now,
+            "anomaly_event": event,
+            "status": status,
+            "tags": ["test_tag", anomaly_type.lower()]
+        }
+        return record
+
+    def test_store_incident_success(self):
+        incident_id = "incident_store_001"
+        sample_record = self._create_sample_incident_record(incident_id, anomaly_type="RHYTHM_BREAK", status="OPEN")
+
+        success = self.lis_cache.store_incident(sample_record)
+        self.assertTrue(success, "store_incident should return True on success.")
+
+        # Verify data in mock HAM
+        # HAMLISCache stores one record per call to store_incident
+        self.assertEqual(len(self.mock_ham_manager.core_memory_store), 1, "One record should be in mock HAM.")
+
+        stored_ham_entry_key = list(self.mock_ham_manager.core_memory_store.keys())[0]
+        stored_ham_entry = self.mock_ham_manager.core_memory_store[stored_ham_entry_key]
+
+        # Check data_type
+        expected_data_type = f"{LIS_INCIDENT_DATA_TYPE_PREFIX}RHYTHM_BREAK"
+        self.assertEqual(stored_ham_entry["data_type"], expected_data_type)
+
+        # Check metadata
+        expected_metadata = {
+            HAM_META_LIS_OBJECT_ID: incident_id,
+            HAM_META_LIS_ANOMALY_TYPE: "RHYTHM_BREAK",
+            "lis_severity": sample_record["anomaly_event"]["severity_score"],
+            HAM_META_LIS_STATUS: "OPEN",
+            HAM_META_LIS_TAGS: ["test_tag", "rhythm_break"],
+            HAM_META_TIMESTAMP_LOGGED: sample_record["timestamp_logged"]
+        }
+        self.assertEqual(stored_ham_entry["metadata"], expected_metadata)
+
+        # Check raw_data (should be JSON string of the sample_record)
+        try:
+            deserialized_raw_data = json.loads(stored_ham_entry["raw_data"])
+            self.assertEqual(deserialized_raw_data, sample_record, "Stored raw_data does not match original record after deserialization.")
+        except json.JSONDecodeError:
+            self.fail("Stored raw_data was not valid JSON.")
+
+    def test_get_incident_by_id_found(self):
+        incident_id = "incident_get_002"
+        sample_record = self._create_sample_incident_record(incident_id)
+        serialized_record = json.dumps(sample_record)
+
+        # Manually populate mock HAM
+        ham_mem_id = self.mock_ham_manager._generate_memory_id()
+        anomaly_event_type = sample_record["anomaly_event"]["anomaly_type"]
+        self.mock_ham_manager.core_memory_store[ham_mem_id] = {
+            "raw_data": serialized_record,
+            "data_type": f"{LIS_INCIDENT_DATA_TYPE_PREFIX}{anomaly_event_type}",
+            "metadata": {
+                HAM_META_LIS_OBJECT_ID: incident_id,
+                HAM_META_LIS_ANOMALY_TYPE: anomaly_event_type,
+                HAM_META_TIMESTAMP_LOGGED: sample_record["timestamp_logged"]
+                # Other metadata fields for completeness if query_core_memory uses them strictly
+            }
+        }
+
+        retrieved_record = self.lis_cache.get_incident_by_id(incident_id)
+        self.assertIsNotNone(retrieved_record, "Should retrieve the incident.")
+        self.assertEqual(retrieved_record, sample_record, "Retrieved record does not match the original.")
+
+    def test_get_incident_by_id_not_found(self):
+        retrieved_record = self.lis_cache.get_incident_by_id("non_existent_id_123")
+        self.assertIsNone(retrieved_record, "Should return None for a non-existent incident ID.")
+
+    def test_store_and_get_incident_roundtrip(self):
+        incident_id = "incident_roundtrip_003"
+        original_record = self._create_sample_incident_record(incident_id, anomaly_type="LOW_DIVERSITY", status="CLOSED_RESOLVED")
+
+        store_success = self.lis_cache.store_incident(original_record)
+        self.assertTrue(store_success, "Storing the incident should succeed.")
+
+        retrieved_record = self.lis_cache.get_incident_by_id(incident_id)
+        self.assertIsNotNone(retrieved_record, "Retrieving the stored incident should not return None.")
+
+        # Compare relevant fields. Timestamps might have microsecond differences if regenerated.
+        # The sample record generates timestamp_logged at creation.
+        # If HAMLISCache.store_incident were to *overwrite* timestamp_logged, this test would need adjustment.
+        # Currently, it uses the one from the input record for metadata.
+        self.assertEqual(retrieved_record, original_record, "Retrieved record does not match the original stored record.")
+
+    def test_store_incident_missing_anomaly_event(self):
+        # Test storing an LIS_IncidentRecord that's missing the 'anomaly_event'
+        incident_id = "incident_bad_004"
+        # Create a record that's intentionally missing 'anomaly_event'
+        bad_record = { # type: ignore
+            "incident_id": incident_id,
+            "timestamp_logged": datetime.now().isoformat(),
+            # "anomaly_event": {...} // Missing
+            "status": "OPEN"
+        }
+        success = self.lis_cache.store_incident(cast(LIS_IncidentRecord, bad_record))
+        self.assertFalse(success, "store_incident should return False if anomaly_event is missing.")
+        self.assertEqual(len(self.mock_ham_manager.core_memory_store), 0, "No record should be stored if anomaly_event is missing.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Implement `HAMLISCache.store_incident()`:
    - Constructs HAM `data_type` using LIS_INCIDENT_DATA_TYPE_PREFIX.
    - Extracts key fields into HAM metadata using defined constants.
    - Serializes `LIS_IncidentRecord` to JSON for `raw_data`.
    - Calls `ham_manager.store_experience()`.
- Implement `HAMLISCache.get_incident_by_id()`:
    - Queries HAM using metadata filters (lis_object_id, data_type_filter).
    - Deserializes JSON from `rehydrated_gist` to `LIS_IncidentRecord`.
- Create `tests/core_ai/lis/test_ham_lis_cache.py`:
    - Includes `MockHAMMemoryManager`.
    - Adds unit tests for `store_incident` and `get_incident_by_id`, covering success, not found, roundtrip, and invalid input cases.
- Define LIS-specific constants (data type prefixes, metadata keys) in `src/core_ai/lis/lis_cache_interface.py`.
- Add `__init__.py` to `tests/core_ai/lis/`.
- Correct import paths in:
    - `src/core_ai/lis/lis_cache_interface.py` (use own constants, `src.` prefix for other imports)
    - `src/core_ai/memory/ham_memory_manager.py` (`src.` prefix for common_types)
    - `tests/core_ai/lis/test_ham_lis_cache.py` (import LIS constants correctly)
- Add `typing-extensions` to `requirements.txt` and install.