### PR TITLE
docs: Align project documentation with current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The **Unified-AI-Project** aims to create a versatile and intelligent conversational AI framework. It consolidates and enhances capabilities from previous projects like MikoAI, Fragmenta, and other CatAI initiatives. The primary goal is to build a modular, maintainable, and extensible system capable of rich dialogue, context understanding, learning, and tool usage.
 
-For details on the initial project structure, merge strategy, and architectural principles that guided the consolidation, please refer to the [MERGE_AND_RESTRUCTURE_PLAN.md](MERGE_AND_RESTRUCTURE_PLAN.md).
+For details on the initial project structure, merge strategy, and architectural principles that guided the consolidation, please refer to the [MERGE_AND_RESTRUCTURE_PLAN.md](MERGE_AND_RESTRUCTURE_PLAN.md). For a summary of the current implementation status of various components, see [Project Status Summary](docs/PROJECT_STATUS_SUMMARY.md), and for an overview of how project files are organized, see [Project Content Organization](docs/PROJECT_CONTENT_ORGANIZATION.md).
 
 ### Future Vision
 

--- a/TODO_PLACEHOLDERS.md
+++ b/TODO_PLACEHOLDERS.md
@@ -69,15 +69,13 @@ These are comments that were picked up by the search but are not actionable code
     *   Line ~216: `# TODO: Consider a transformation step if strict snake_case is required internally for these.` (Comment suggesting a potential future refactor for field naming in `OllamaChatHistoryEntry`)
     *   Line ~410: `id: str # The memory_id (mem_XXXXXX)` (A clarifying comment for a field, not a placeholder to be filled.)
 
-## 4. Data Placeholders (Non-code)
+## 4. Data Anomalies (Previously "Data Placeholders")
 
-These are placeholders found within data files, not code.
+Anomalies observed within data files.
 
 *   **File:** `data/processed_data/dialogue_context_memory.json`
-    *   **Lines:** Multiple instances (e.g., L699, L1035, L1613, L1823 based on grep results)
-    *   **Placeholder:** `"XXX"` found within `encrypted_package_b64` string values.
-    *   **Context:** These appear as segments within base64 encoded encrypted data strings.
-    *   **Summary:** This suggests that some encrypted data packages are incomplete, truncated, or are using "XXX" as a placeholder for actual encrypted content. This could be a data integrity issue.
-    *   **Further Context & Hypothesis:** An alternative interpretation is that "XXX" (or similar markers) may represent a form of "Deep Mapping" – a resource-saving transformation or encoding of data managed by the Hierarchical Associative Memory (HAM). For a detailed explanation of this hypothesis and its relation to personality simulation, see [`docs/architecture/DEEP_MAPPING_AND_PERSONALITY_SIMULATION.md`](docs/architecture/DEEP_MAPPING_AND_PERSONALITY_SIMULATION.md). Investigation into HAM's storage and retrieval mechanisms would be needed to confirm this.
+    *   **Observation:** The string `"XXX"` has been found as a substring within some `encrypted_package_b64` values.
+    *   **Clarification (as of July 8, 2024):** Initial hypotheses suggested "XXX" might be a special placeholder or a "Deep Mapping" token. However, further investigation, detailed in `docs/architecture/DEEP_MAPPING_AND_PERSONALITY_SIMULATION.md` and summarized in `docs/PROJECT_STATUS_SUMMARY.md` (Section 2), has concluded that these "XXX" sequences are **coincidental substrings** within normally processed (abstracted, compressed, encrypted) HAM data.
+    *   **Current Understanding:** These occurrences are not indicative of a deliberate "Deep Mapping" token system or placeholders for missing data in that sense. They are artifacts of the standard data transformation pipeline. While the concept of advanced Deep Mapping remains a potential future architectural goal, it is not represented by these "XXX" findings. Any perceived incompleteness or issues with such data packages should be investigated as potential data integrity or processing artifacts rather than special markers.
 
 This summary provides a clear overview of outstanding tasks and points of interest related to placeholders and TODOs in the project.

--- a/docs/PROJECT_CONTENT_ORGANIZATION.md
+++ b/docs/PROJECT_CONTENT_ORGANIZATION.md
@@ -19,6 +19,8 @@ Key files at the project root:
 
 Contains the core Python source code for the AI and its services.
 
+*   `core_services.py`: Provides central initialization (dependency injection) and access to core AI service instances. Responsible for instantiating and wiring together major components like DialogueManager, Memory, LLMInterface, etc.
+
 ### 2.1. Core AI Logic (`src/core_ai/`)
 
 Houses the central intelligence and decision-making components of the AI.
@@ -41,6 +43,7 @@ Houses the central intelligence and decision-making components of the AI.
     *   `service_discovery_module.py`: Manages discovery and registry of capabilities advertised by other AIs on the HSP network.
 *   **`trust_manager/`**:
     *   `trust_manager_module.py`: Manages trust scores for interactions with other AI peers in the HSP network.
+*   **`lis/`**: Contains early placeholders (`lis_cache_interface.py`) for the Linguistic Immune System (LIS), a conceptual system for advanced error processing and linguistic evolution (see `docs/architecture/Linguistic_Immune_System_spec.md`).
 *   `emotion_system.py`: Manages and simulates the AI's emotional state.
 *   `crisis_system.py`: Assesses input for crisis situations and can trigger appropriate responses.
 *   `time_system.py`: Provides time-related context (e.g., time of day).
@@ -58,6 +61,7 @@ Contains internal "tools" that the AI can use to augment its capabilities.
 
 *   `tool_dispatcher.py`: Enables the AI to select and use various tools.
 *   `math_tool.py`, `logic_tool.py`, `translation_tool.py`: Example or actual implementations of specific tools.
+*   `code_understanding_tool.py`: A callable tool providing code understanding capabilities.
 *   Subdirectories like `math_model/`, `logic_model/`, `translation_model/` likely contain machine learning models or data related to these tools.
 *   `js_tool_dispatcher/`: Appears to be for dispatching tools implemented in JavaScript.
 
@@ -78,6 +82,8 @@ Backend services, including API servers and interfaces to external systems.
 *   `llm_interface.py`: Standardized interface for interacting with various Large Language Models (e.g., Ollama, OpenAI).
 *   `sandbox_executor.py`: For safely executing code, likely used in tool drafting or other dynamic code execution scenarios.
 *   `audio_service.py`, `vision_service.py`: Placeholders or implementations for audio and vision processing capabilities.
+*   `resource_awareness_service.py`: Manages and provides information about the AI's simulated hardware resources, configured via `configs/simulated_resources.yaml`.
+*   `ai_virtual_input_service.py`: Implements the AI Virtual Input Service (AVIS) for simulated GUI interaction (e.g., virtual mouse/keyboard). (See `docs/architecture/AI_Virtual_Input_System_spec.md`).
 *   `node_services/`: Contains a Node.js server, possibly for supporting JavaScript-based tools or UI backend components.
 *   `api_models.py`: Defines Pydantic models for API request/response validation.
 
@@ -121,6 +127,7 @@ Centralized configuration for various aspects of the AI system.
 *   `system_config.yaml`: General system-wide configurations.
 *   `api_keys.yaml`: Structure and placeholders for external API keys (actual keys typically via `.env`).
 *   `ontology_mappings.yaml`: Mappings for ontologies, likely used by `ContentAnalyzerModule`.
+*   `simulated_resources.yaml`: Defines profiles for simulated hardware resources, used by the `ResourceAwarenessService`.
 *   `version_manifest.json`: Manages versions of different components or data schemas.
 *   **`formula_configs/`**:
     *   `default_formulas.json`: Defines rules for the Formula Engine.


### PR DESCRIPTION
Updates key markdown files to improve consistency and accurately reflect the project's structure and status:

- README.md: Added links to PROJECT_STATUS_SUMMARY.md and PROJECT_CONTENT_ORGANIZATION.md for better navigation.
- TODO_PLACEHOLDERS.md: Clarified that 'XXX' substrings in data are coincidental, not 'Deep Mapping' tokens, aligning with current understanding in DEEP_MAPPING_AND_PERSONALITY_SIMULATION.md and PROJECT_STATUS_SUMMARY.md.
- docs/PROJECT_CONTENT_ORGANIZATION.md: Added brief descriptions and links for previously undocumented or under-documented components:
    - src/core_services.py (central service initializer)
    - src/core_ai/lis/ (LIS placeholder, linked to spec)
    - src/tools/code_understanding_tool.py
    - src/services/resource_awareness_service.py (and its config configs/simulated_resources.yaml)
    - src/services/ai_virtual_input_service.py (AVIS, linked to spec)

These changes ensure that the primary documentation files are more comprehensive and guide developers more effectively.