### PR TITLE
feat(hsp): Verify and test ACK sending in HSPConnector

### DIFF
--- a/TODO_PLACEHOLDERS.md
+++ b/TODO_PLACEHOLDERS.md
@@ -42,10 +42,10 @@ These are comments indicating planned work or missing functionality that require
     *   **Placeholder:** `"payload_schema_uri": None, # TODO: Add schema URIs when defined`
     *   **Context:** Within the `_build_hsp_envelope` method.
     *   **Required Functionality:** Update this to populate the `payload_schema_uri` field with appropriate URIs once the HSP message payload schemas are formally defined and published.
-    *   **Line:** ~260
-    *   **Placeholder:** `# TODO: Implement logic for sending ACKs if the received message's qos_parameters.requires_ack is true.`
-    *   **Context:** In the `_handle_hsp_message_str` method.
-    *   **Required Functionality:** Implement the part of the HSP protocol responsible for sending acknowledgement (ACK) messages back to the sender if an incoming message indicates it requires an ACK (based on its `qos_parameters`).
+    *   **Line:** ~260 (Original TODO location)
+    *   **Placeholder:** `# CLARIFIED: Logic for sending 'received' ACKs when qos_parameters.requires_ack is true is implemented in _handle_hsp_message_str and _send_acknowledgement.`
+    *   **Context:** Was in the `_handle_hsp_message_str` method.
+    *   **Required Functionality:** (Addressed for 'received' ACKs) The connector sends 'received' ACKs as required. Functionality verified and tested in `feat/hsp-ack-handling`. (Future enhancements could include 'processed' ACKs or NACKs).
 
 *   **File:** `src/interfaces/electron_app/renderer.js`
     *   **Line:** ~137

--- a/src/hsp/connector.py
+++ b/src/hsp/connector.py
@@ -313,9 +313,7 @@ class HSPConnector:
 
     def _send_acknowledgement(self, target_ai_id: str, acknowledged_message_id: str, status: Literal["received", "processed"], ack_topic: str, version: str = "0.1"):
         """Helper method to construct and send an HSP Acknowledgement message."""
-        # Ensure HSPAcknowledgementPayload is defined or imported from .types
-        # For now, assuming it's a dict-like structure if not strictly typed yet
-        ack_payload: Dict[str, Any] = { # HSPAcknowledgementPayload
+        ack_payload: HSPAcknowledgementPayload = {
             "status": status,
             "ack_timestamp": datetime.now(timezone.utc).isoformat(),
             "target_message_id": acknowledged_message_id
@@ -323,7 +321,7 @@ class HSPConnector:
         ack_message_type = f"HSP::Acknowledgement_v{version}"
 
         envelope = self._build_hsp_envelope(
-            payload=ack_payload, # payload=dict(ack_payload) if strictly TypedDict
+            payload=ack_payload, # TypedDict is compatible with Dict[str, Any]
             message_type=ack_message_type,
             recipient_ai_id_or_topic=ack_topic,
             communication_pattern="acknowledgement",


### PR DESCRIPTION
This commit verifies the existing 'received' ACK sending functionality in `HSPConnector` and adds comprehensive unit tests for it.

- Reviewed existing ACK logic in `_handle_hsp_message_str` and `_send_acknowledgement` against HSP specification basics. The current implementation for sending 'received' ACKs when `qos_parameters.requires_ack` is true is sound.
- Made a minor refinement in `_send_acknowledgement` to use the specific `HSPAcknowledgementPayload` type hint.

Testing:
- Added a new test class `TestHSPConnectorACKLogic` to `tests/hsp/test_hsp_connector.py`.
- New unit tests cover:
    - Verification that ACKs are sent if `requires_ack` is true.
    - Verification that ACKs are not sent if `requires_ack` is false or absent.
    - Correct construction of the ACK message envelope and payload, including timestamp validation.

Documentation:
- Updated `TODO_PLACEHOLDERS.md` to reflect that the TODO item for ACK implementation is now addressed for 'received' ACKs.