### PR TITLE
docs: Clarify ServiceDiscoveryModule discrepancy and prerequisites

### DIFF
--- a/TODO_PLACEHOLDERS.md
+++ b/TODO_PLACEHOLDERS.md
@@ -31,6 +31,7 @@ These are comments indicating planned work or missing functionality that require
     *   **Line:** ~177
     *   **Placeholder:** `# TODO: Add logic for staleness/expiration of capabilities based on self.last_seen`
     *   **Context:** End of the class definition.
+    *   **Prerequisite Note:** The `ServiceDiscoveryModule` at this path currently implements a generic service registry. It must be refactored or replaced to align with the HSP-specific interface (handling `HSPCapabilityAdvertisementPayload`, integrating with `TrustManager`, having `process_capability_advertisement` method) as expected by `core_services.py` before this staleness logic for HSP capabilities can be implemented. (See also notes in `PROJECT_STATUS_SUMMARY.md` and `PROJECT_CONTENT_ORGANIZATION.md`).
     *   **Required Functionality:** Implement a mechanism to automatically mark or remove advertised HSP capabilities if they haven't been re-advertised or "seen" for a defined period, to avoid using stale service information.
 
 *   **File:** `src/hsp/connector.py`

--- a/docs/PROJECT_CONTENT_ORGANIZATION.md
+++ b/docs/PROJECT_CONTENT_ORGANIZATION.md
@@ -40,7 +40,7 @@ Houses the central intelligence and decision-making components of the AI.
 *   **`code_understanding/`**:
     *   `lightweight_code_model.py`: Provides basic static analysis of Python code, particularly for understanding tool structures.
 *   **`service_discovery/`**:
-    *   `service_discovery_module.py`: Manages discovery and registry of capabilities advertised by other AIs on the HSP network.
+    *   `service_discovery_module.py`: Contains a service discovery implementation. **Note:** Its current code defines a generic service registry with TTL-based expiry and its own `ServiceAdvertisement` type. This differs from the HSP-specific capability discovery mechanism (expected to handle `HSPCapabilityAdvertisementPayload`, integrate with `TrustManager`, and have a `process_capability_advertisement` method) that is anticipated by `core_services.py` for HSP integration. This module requires refactoring or replacement to fulfill the HSP-related role.
 *   **`trust_manager/`**:
     *   `trust_manager_module.py`: Manages trust scores for interactions with other AI peers in the HSP network.
 *   **`lis/`**: Contains early placeholders (`lis_cache_interface.py`) for the Linguistic Immune System (LIS), a conceptual system for advanced error processing and linguistic evolution (see `docs/architecture/Linguistic_Immune_System_spec.md`).

--- a/docs/PROJECT_STATUS_SUMMARY.md
+++ b/docs/PROJECT_STATUS_SUMMARY.md
@@ -98,13 +98,13 @@ This summary is based on automated code and documentation review.
     *   Sending task requests and results.
     *   Subscribing to topics and basic message handling.
     *   Callback registration for different message types.
-    *   `ServiceDiscoveryModule` for managing known capabilities from peers, including trust score integration.
+    *   `ServiceDiscoveryModule` (intended for HSP capabilities): The instantiation in `core_services.py` expects this module to integrate with `TrustManager` and process `HSPCapabilityAdvertisementPayload` via a `process_capability_advertisement` method. **However, the current file at `src/core_ai/service_discovery/service_discovery_module.py` implements a generic service registry with a different interface and functionality.** This module requires significant refactoring or replacement to fulfill its intended HSP role.
     *   Basic trust management via `TrustManager`.
 *   **Pending (Explicit TODOs from `TODO_PLACEHOLDERS.md`):**
-    *   `hsp/connector.py` (Line ~63): Implement MQTT reconnection strategy in `_on_mqtt_disconnect`.
+    *   `hsp/connector.py` (Line ~63): CLARIFIED: Reconnection strategy is handled by the Paho MQTT client. (Verified in `feat/hsp-connector-robustness`).
     *   `hsp/connector.py` (Line ~128): Add schema URIs to `payload_schema_uri` in `_build_hsp_envelope` when defined.
-    *   `hsp/connector.py` (Line ~260): Implement logic for sending ACKs if `requires_ack` is true.
-    *   `service_discovery_module.py` (Line ~177): Add logic for staleness/expiration of capabilities.
+    *   `hsp/connector.py` (Line ~260): CLARIFIED: Logic for sending 'received' ACKs is implemented. (Verified in `feat/hsp-ack-handling`).
+    *   `service_discovery_module.py` (HSP-specific version, Line ~177 in `TODO_PLACEHOLDERS.md`): Add logic for staleness/expiration of capabilities. **Prerequisite: This module must first be correctly implemented/refactored to handle HSP capabilities and integrate with `TrustManager` as expected by `core_services.py`.**
 *   **Further Development / Conceptual Goals:**
     *   Full adherence to `docs/HSP_SPECIFICATION.md` (this spec itself needs review to identify further gaps).
     *   More robust error handling and message validation.


### PR DESCRIPTION
Updated project documentation to reflect the inconsistency between the current content of `src/core_ai/service_discovery/service_discovery_module.py` and its expected role in HSP capability management.

Changes:
- `docs/PROJECT_CONTENT_ORGANIZATION.md`: Updated the description for `ServiceDiscoveryModule` to note its current generic implementation and the need for refactoring/replacement for HSP purposes.
- `docs/PROJECT_STATUS_SUMMARY.md`: Clarified that the implemented `ServiceDiscoveryModule` does not match HSP requirements and that relevant TODOs depend on a correctly defined HSP-specific version. Also updated status of some HSPConnector TODOs.
- `TODO_PLACEHOLDERS.md`: Added a prerequisite note to the `ServiceDiscoveryModule` staleness TODO, emphasizing the need for module alignment with HSP integration before the staleness logic can be addressed.