### PR TITLE
feat(core_ai): Implement tool name resolution in LightweightCodeModel

### DIFF
--- a/TODO_PLACEHOLDERS.md
+++ b/TODO_PLACEHOLDERS.md
@@ -22,10 +22,10 @@ These are values intended to be replaced by actual secrets or configurations, ty
 These are comments indicating planned work or missing functionality that requires code implementation.
 
 *   **File:** `src/core_ai/code_understanding/lightweight_code_model.py`
-    *   **Line:** ~177
-    *   **Placeholder:** `# TODO: Add logic to resolve tool_name to filepath if not already a path.`
-    *   **Context:** In the `get_tool_structure` method.
-    *   **Required Functionality:** Implement logic to find a tool's Python file using its name by searching within the `tools_directory`, if a direct file path is not provided as input.
+    *   **Line:** ~177 (Original TODO location in `get_tool_structure`)
+    *   **Placeholder:** `# COMPLETED: Logic to resolve tool_name to a filepath has been implemented.`
+    *   **Context:** Was in the `get_tool_structure` method.
+    *   **Required Functionality:** (Implemented in `feat/lcm-tool-name-resolution`) The `get_tool_structure` method now resolves `tool_path_or_name` by checking if it's a direct path, then attempting to find `name.py`, `tool_name.py`, or `name_tool.py` in the configured `tools_directory`.
 
 *   **File:** `src/core_ai/service_discovery/service_discovery_module.py`
     *   **Line:** ~177 (Original TODO location in a previous version of the file)

--- a/tests/core_ai/code_understanding/test_lightweight_code_model.py
+++ b/tests/core_ai/code_understanding/test_lightweight_code_model.py
@@ -3,6 +3,8 @@ from unittest.mock import patch, mock_open
 import os
 import glob
 import ast # Ensure ast is imported for any direct ast comparisons if needed, though unparse is main
+import tempfile # For temporary directory
+import logging # For self.assertLogs
 
 # Assuming src is in PYTHONPATH for test execution
 from src.core_ai.code_understanding.lightweight_code_model import LightweightCodeModel
@@ -10,49 +12,54 @@ from src.core_ai.code_understanding.lightweight_code_model import LightweightCod
 class TestLightweightCodeModel(unittest.TestCase):
 
     def setUp(self):
-        self.mock_tools_dir = "src/tools/"
-        self.model = LightweightCodeModel(tools_directory=self.mock_tools_dir)
+        # Create a temporary directory for tools
+        self.temp_dir_obj = tempfile.TemporaryDirectory()
+        self.temp_tools_dir = self.temp_dir_obj.name
+        self.model = LightweightCodeModel(tools_directory=self.temp_tools_dir)
+        # It's good practice to also capture logs if the module emits them during tests
+        # self.logger_patcher = patch('src.core_ai.code_understanding.lightweight_code_model.logger')
+        # self.mock_logger = self.logger_patcher.start()
 
-    @patch('glob.glob')
-    @patch('os.path.isdir')
-    @patch('os.path.basename') # Mock basename as it's used by list_tool_files
-    def test_list_tool_files(self, mock_os_path_basename, mock_os_path_isdir, mock_glob_glob):
-        mock_os_path_isdir.return_value = True
-        # Simulate glob finding these files
-        glob_paths = [
-            os.path.join(self.mock_tools_dir, "tool_one.py"),
-            os.path.join(self.mock_tools_dir, "__init__.py"),
-            os.path.join(self.mock_tools_dir, "tool_two.py"),
-            os.path.join(self.mock_tools_dir, "tool_dispatcher.py"),
-            os.path.join(self.mock_tools_dir, "subdir", "tool_three.py") # Test subdirectory case
-        ]
-        mock_glob_glob.return_value = glob_paths
+    def tearDown(self):
+        # Clean up the temporary directory
+        self.temp_dir_obj.cleanup()
+        # self.logger_patcher.stop()
 
-        # Configure side_effect for os.path.basename
-        mock_os_path_basename.side_effect = [
-            "tool_one.py",
-            "__init__.py",
-            "tool_two.py",
-            "tool_dispatcher.py",
-            "tool_three.py"
-        ]
+    def test_list_tool_files(self):
+        # Create dummy files and a subdirectory in the temp_tools_dir
+        self._create_dummy_tool_file("tool_one.py")
+        self._create_dummy_tool_file("__init__.py") # Should be excluded
+        self._create_dummy_tool_file("tool_two.py")
+        self._create_dummy_tool_file("tool_dispatcher.py") # Should be excluded
+
+        subdir = os.path.join(self.temp_tools_dir, "subdir")
+        os.makedirs(subdir)
+        self._create_dummy_tool_file(os.path.join("subdir", "tool_three.py"))
+        self._create_dummy_tool_file(os.path.join("subdir", "another_tool.py"))
+        self._create_dummy_tool_file(os.path.join("subdir", "__init__.py")) # Excluded from subdir too
+
+        # Non-python file
+        with open(os.path.join(self.temp_tools_dir, "data.txt"), "w") as f:
+            f.write("text")
 
         expected_files = [
-            os.path.join(self.mock_tools_dir, "tool_one.py"),
-            os.path.join(self.mock_tools_dir, "tool_two.py"),
-            os.path.join(self.mock_tools_dir, "subdir", "tool_three.py")
+            os.path.join(self.temp_tools_dir, "tool_one.py"),
+            os.path.join(self.temp_tools_dir, "tool_two.py"),
+            os.path.join(self.temp_tools_dir, "subdir", "tool_three.py"),
+            os.path.join(self.temp_tools_dir, "subdir", "another_tool.py")
         ]
 
         tool_files = self.model.list_tool_files()
-        self.assertCountEqual(tool_files, expected_files, "Should list correct tool files, excluding __init__ and dispatcher.")
-        mock_glob_glob.assert_called_once_with(os.path.join(self.mock_tools_dir, "**", "*.py"), recursive=True)
+        self.assertCountEqual(tool_files, expected_files,
+                              "Should list correct tool files, excluding __init__ and dispatcher, and include those in subdirs.")
 
+    def test_list_tool_files_non_existent_dir(self):
+        # This test now implicitly uses the logger due to changes in __init__
+        with self.assertLogs(logger='src.core_ai.code_understanding.lightweight_code_model', level='WARNING') as cm:
+            model = LightweightCodeModel(tools_directory="non_existent_dir_for_list_test/")
+        self.assertTrue(any("Tools directory 'non_existent_dir_for_list_test/' does not exist" in record.getMessage() for record in cm.records))
 
-    @patch('os.path.isdir')
-    def test_list_tool_files_non_existent_dir(self, mock_isdir):
-        mock_isdir.return_value = False
-        model = LightweightCodeModel(tools_directory="non_existent_dir/")
-        tool_files = model.list_tool_files()
+        tool_files = model.list_tool_files() # Should return empty list as dir doesn't exist
         self.assertEqual(tool_files, [])
 
     def test_analyze_tool_file_simple_class_and_function(self):
@@ -168,34 +175,108 @@ def module_level_func(x: float, *args, y: float = 3.14, **kwargs) -> List[float]
             analysis_result = self.model.analyze_tool_file("non_existent_file.py")
         self.assertIsNone(analysis_result)
 
-    @patch('os.path.isfile')
-    def test_get_tool_structure_direct_path(self, mock_isfile):
-        mock_isfile.return_value = True
-        with patch.object(self.model, 'analyze_tool_file', return_value={"mocked": "analysis"}) as mock_analyze:
-            result = self.model.get_tool_structure("src/tools/some_tool.py")
-            mock_analyze.assert_called_once_with("src/tools/some_tool.py")
-            self.assertEqual(result, {"mocked": "analysis"})
+    # --- Tests for get_tool_structure name resolution ---
 
-    @patch('os.path.join')
-    @patch('os.path.isfile')
-    def test_get_tool_structure_tool_name_resolution(self, mock_isfile, mock_join):
-        mock_isfile.side_effect = [False, True]
-        resolved_path = os.path.join(self.mock_tools_dir, "my_tool.py")
-        mock_join.return_value = resolved_path
+    def _create_dummy_tool_file(self, filename: str, content: str = "def main(): pass"):
+        filepath = os.path.join(self.temp_tools_dir, filename)
+        with open(filepath, "w") as f:
+            f.write(content)
+        return filepath
 
-        with patch.object(self.model, 'analyze_tool_file', return_value={"resolved": "analysis"}) as mock_analyze:
-            result = self.model.get_tool_structure("my_tool")
-            # Check if the specific call we care about was made, among potentially others
-            self.assertIn(unittest.mock.call(self.mock_tools_dir, "my_tool"), mock_join.call_args_list)
-            mock_analyze.assert_called_once_with(resolved_path)
-            self.assertEqual(result, {"resolved": "analysis"})
+    def test_get_tool_structure_direct_valid_path(self):
+        dummy_tool_path = self._create_dummy_tool_file("actual_tool.py")
+        # We mock analyze_tool_file to isolate testing of path resolution logic
+        with patch.object(self.model, 'analyze_tool_file', return_value={"analysis": "done"}) as mock_analyze:
+            result = self.model.get_tool_structure(dummy_tool_path)
+            mock_analyze.assert_called_once_with(dummy_tool_path)
+            self.assertEqual(result, {"analysis": "done"})
 
-    @patch('os.path.isfile', return_value=False)
-    def test_get_tool_structure_tool_not_found(self, mock_isfile):
-        with patch.object(self.model, 'analyze_tool_file') as mock_analyze:
-            result = self.model.get_tool_structure("non_existent_tool")
-            mock_analyze.assert_not_called()
+    def test_get_tool_structure_direct_invalid_path(self):
+        invalid_path = os.path.join(self.temp_tools_dir, "non_existent_tool.py")
+        with self.assertLogs(logger='src.core_ai.code_understanding.lightweight_code_model', level='WARNING') as cm:
+            result = self.model.get_tool_structure(invalid_path)
             self.assertIsNone(result)
+        self.assertTrue(any(f"appears to be a path but was not found" in record.getMessage() for record in cm.records))
+
+    def test_get_tool_structure_path_looks_like_path_but_not_found(self):
+        # This tests the case where the input string contains path separators but doesn't exist
+        path_like_non_existent = "some_dir/non_existent_tool.py"
+        # Ensure this path doesn't accidentally exist relative to where test runs
+        self.assertFalse(os.path.isfile(path_like_non_existent))
+
+        with self.assertLogs(logger='src.core_ai.code_understanding.lightweight_code_model', level='WARNING') as cm:
+            result = self.model.get_tool_structure(path_like_non_existent)
+        self.assertIsNone(result)
+        self.assertTrue(any(f"appears to be a path but was not found" in record.getMessage() for record in cm.records))
+
+    def test_get_tool_structure_resolve_exact_name_dot_py(self):
+        self._create_dummy_tool_file("exact_match.py")
+        with patch.object(self.model, 'analyze_tool_file', return_value={"analyzed": "exact_match.py"}) as mock_analyze:
+            # Test with extension
+            result_with_ext = self.model.get_tool_structure("exact_match.py")
+            mock_analyze.assert_called_with(os.path.join(self.temp_tools_dir, "exact_match.py"))
+            self.assertEqual(result_with_ext, {"analyzed": "exact_match.py"})
+
+            mock_analyze.reset_mock()
+            # Test without extension
+            result_without_ext = self.model.get_tool_structure("exact_match")
+            mock_analyze.assert_called_with(os.path.join(self.temp_tools_dir, "exact_match.py"))
+            self.assertEqual(result_without_ext, {"analyzed": "exact_match.py"})
+
+    def test_get_tool_structure_resolve_tool_prefix_pattern(self):
+        self._create_dummy_tool_file("tool_sample_prefix.py")
+        with patch.object(self.model, 'analyze_tool_file', return_value={"analyzed": "tool_sample_prefix.py"}) as mock_analyze:
+            result = self.model.get_tool_structure("sample_prefix")
+            mock_analyze.assert_called_once_with(os.path.join(self.temp_tools_dir, "tool_sample_prefix.py"))
+            self.assertEqual(result, {"analyzed": "tool_sample_prefix.py"})
+
+    def test_get_tool_structure_resolve_suffix_tool_pattern(self):
+        self._create_dummy_tool_file("sample_suffix_tool.py")
+        with patch.object(self.model, 'analyze_tool_file', return_value={"analyzed": "sample_suffix_tool.py"}) as mock_analyze:
+            result = self.model.get_tool_structure("sample_suffix")
+            mock_analyze.assert_called_once_with(os.path.join(self.temp_tools_dir, "sample_suffix_tool.py"))
+            self.assertEqual(result, {"analyzed": "sample_suffix_tool.py"})
+
+    def test_get_tool_structure_prefers_exact_over_pattern(self):
+        self._create_dummy_tool_file("pref_exact.py", content="# exact content")
+        self._create_dummy_tool_file("tool_pref_exact.py", content="# tool_prefix content")
+        # analyze_tool_file will be mocked to return the path it was called with for simplicity
+        def side_effect_analyzer(filepath): return {"path": filepath}
+
+        with patch.object(self.model, 'analyze_tool_file', side_effect=side_effect_analyzer) as mock_analyze:
+            result = self.model.get_tool_structure("pref_exact")
+            # It should find "pref_exact.py" directly
+            mock_analyze.assert_called_once_with(os.path.join(self.temp_tools_dir, "pref_exact.py"))
+            self.assertEqual(result, {"path": os.path.join(self.temp_tools_dir, "pref_exact.py")})
+
+    def test_get_tool_structure_ambiguous_patterns(self):
+        self._create_dummy_tool_file("tool_ambiguous_pattern.py")
+        self._create_dummy_tool_file("ambiguous_pattern_tool.py")
+        with self.assertLogs(logger='src.core_ai.code_understanding.lightweight_code_model', level='WARNING') as cm:
+            result = self.model.get_tool_structure("ambiguous_pattern")
+        self.assertIsNone(result)
+        self.assertTrue(any("Ambiguous tool name 'ambiguous_pattern'" in record.getMessage() for record in cm.records))
+
+    def test_get_tool_structure_name_not_found(self):
+        with self.assertLogs(logger='src.core_ai.code_understanding.lightweight_code_model', level='WARNING') as cm:
+            result = self.model.get_tool_structure("completely_non_existent_tool_name")
+        self.assertIsNone(result)
+        self.assertTrue(any("Could not resolve tool 'completely_non_existent_tool_name'" in record.getMessage() for record in cm.records))
+
+    def test_get_tool_structure_invalid_tools_directory(self):
+        bad_dir_path = "path_that_does_not_exist_at_all_xyz"
+
+        # Test log during __init__
+        with self.assertLogs(logger='src.core_ai.code_understanding.lightweight_code_model', level='WARNING') as init_cm:
+            model_bad_dir = LightweightCodeModel(tools_directory=bad_dir_path)
+        self.assertTrue(any(f"Tools directory '{bad_dir_path}' does not exist or is not a directory." in record.getMessage() for record in init_cm.records))
+
+        # Test log during get_tool_structure
+        with self.assertLogs(logger='src.core_ai.code_understanding.lightweight_code_model', level='WARNING') as get_cm:
+            result = model_bad_dir.get_tool_structure("any_tool_name")
+        self.assertIsNone(result)
+        self.assertTrue(any(f"Tools directory '{bad_dir_path}' is not valid. Cannot resolve tool by name: any_tool_name" in record.getMessage() for record in get_cm.records))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implements logic in `LightweightCodeModel.get_tool_structure` to resolve a tool name to a filepath within the configured tools directory. This addresses the TODO for more robust tool identification.

Key changes to `LightweightCodeModel`:
- Replaced `print` statements with the `logging` module.
- `get_tool_structure` now:
    - Distinguishes between direct file path inputs and tool name inputs.
    - For names, first attempts an exact match (e.g., `tool_name.py`).
    - If no exact match, searches for common patterns like `tool_{basename}.py` and `{basename}_tool.py`.
    - Handles cases such as invalid tools directory, ambiguous matches (multiple patterns found), and no match found, with appropriate logging.
- Updated docstrings to reflect the new resolution behavior.

Unit Test Updates:
- Test suite `test_lightweight_code_model.py` now uses a temporary directory for tool files.
- Added comprehensive new tests for `get_tool_structure` to cover various name/path resolution scenarios, including edge cases and logging checks.
- All tests pass.

Documentation:
- Updated `TODO_PLACEHOLDERS.md` to mark the relevant TODO as complete.