### PR TITLE
refactor: Integrate SandboxExecutor into AISimulationControlService

### DIFF
--- a/src/services/ai_simulation_control_service_readme.md
+++ b/src/services/ai_simulation_control_service_readme.md
@@ -14,14 +14,15 @@ The `AISimulationControlService` (ASCS) is a crucial component within the Unifie
     *   Interfaces with the `ResourceAwarenessService` to fetch the current status of the simulated hardware environment (e.g., CPU, disk space, memory).
     *   Provides this information to other services (like AVIS) so it can be displayed to the AI, allowing the AI to make resource-aware decisions.
 
-3.  **AI-Generated Code Execution:**
-    *   Provides a secure mechanism to execute code strings provided by the AI (e.g., Python scripts).
+3.  **AI-Generated Code Execution (Python):**
+    *   Provides a mechanism to execute Python code strings provided by the AI.
     *   Before execution, it checks the AI's `can_execute_code` permission.
-    *   If permitted, it uses a sandboxed execution environment (typically through the `run_in_bash_session` tool provided by the underlying agent framework) to run the code. This involves:
-        *   Writing the code to a temporary script file within the sandbox.
-        *   Executing the script using the appropriate interpreter (e.g., `python`).
+    *   If permitted, it utilizes the `SandboxExecutor` service (`src/services/sandbox_executor.py`) to run the Python code. The `SandboxExecutor` handles:
+        *   Writing the code to a temporary script file.
+        *   Executing the script in a separate subprocess, providing a degree of isolation.
         *   Capturing `stdout`, `stderr`, and the script's exit code.
-    *   Returns the execution outcome as an `ExecutionResult` TypedDict, which includes the captured output and status messages.
+        *   Handling execution timeouts.
+    *   ASCS returns the execution outcome as an `ExecutionResult` TypedDict, derived from the results provided by `SandboxExecutor`.
 
 ## Key Responsibilities
 
@@ -39,9 +40,9 @@ The `AISimulationControlService` (ASCS) is a crucial component within the Unifie
 *   **`ResourceAwarenessService`:**
     *   ASCS takes an instance of `ResourceAwarenessService` during initialization.
     *   It calls methods on this service (e.g., `get_simulated_hardware_profile()`) to retrieve hardware status information.
-*   **`run_in_bash_session` (Tool/Framework Capability):**
-    *   ASCS is provided with a `bash_runner` callable (expected to be the `run_in_bash_session` tool or a compatible wrapper) during its initialization.
-    *   It uses this runner to execute shell commands that create and run the AI's script in a sandboxed environment.
+*   **`SandboxExecutor`:**
+    *   ASCS requires an instance of `SandboxExecutor` during its initialization.
+    *   It calls `sandbox_executor.execute_python_code()` to run AI-provided Python scripts.
 
 ## Future Enhancements
 

--- a/tests/services/test_ai_virtual_input_service.py
+++ b/tests/services/test_ai_virtual_input_service.py
@@ -41,22 +41,20 @@ class TestAIVirtualInputService(unittest.TestCase):
             "status_message": "Execution completed."
         }
 
-        # Mock ResourceAwarenessService (though AISimulationControlService uses it, AVIS might get it too)
+        # Mock ResourceAwarenessService
         self.mock_resource_service = MagicMock()
 
-        # Mock bash_runner
-        self.mock_bash_runner = MagicMock()
-
-        # Patch 'AISimulationControlService' in the module where AIVirtualInputService imports it
-        # This is cleaner than trying to inject it if AIVisualInputService instantiates it directly.
-        # However, our AIVisualInputService now takes it as an argument (or bash_runner for it).
+        # Mock SandboxExecutor
+        self.mock_sandbox_executor = MagicMock()
 
         self.avis = AIVirtualInputService(
             initial_mode="simulation_only",
-            resource_awareness_service=self.mock_resource_service, # Passed to ASCS
-            bash_runner=self.mock_bash_runner # Passed to ASCS
+            resource_awareness_service=self.mock_resource_service,
+            sandbox_executor=self.mock_sandbox_executor # Pass SandboxExecutor
         )
         # Replace the internally created AISimulationControlService with our mock for fine-grained testing
+        # This allows us to assert calls on mock_sim_control_service without needing to
+        # also mock what AISimulationControlService passes to SandboxExecutor.
         self.avis.ai_simulation_control_service = self.mock_sim_control_service
 
 
@@ -474,7 +472,7 @@ if __name__ == '__main__':
         # Test setup: Create a new AVIS instance, then load UI, then refresh.
         avis_for_init_test = AIVirtualInputService(
             resource_awareness_service=self.mock_resource_service,
-            bash_runner=self.mock_bash_runner
+            sandbox_executor=self.mock_sandbox_executor # Use sandbox_executor
         )
         avis_for_init_test.ai_simulation_control_service = self.mock_sim_control_service # Inject mock
 


### PR DESCRIPTION
Refactors AISimulationControlService (ASCS) to use SandboxExecutor for executing AI-generated Python code, replacing the previous bash_runner mechanism (which used 'echo' and 'python' commands).

Key changes:
- AISimulationControlService:
    - Constructor now requires a SandboxExecutor instance.
    - `execute_ai_code` method now calls `sandbox_executor.execute_python_code()`.
    - Maps results from SandboxExecutor (stdout, stderr, exit_code, error flags) to the ExecutionResult TypedDict, providing more detailed status messages.
- SandboxExecutor:
    - Added `execute_python_code(code_string)` method for direct execution of Python code strings, returning a detailed result dictionary.
- AIVirtualInputService:
    - Constructor updated to accept and pass a SandboxExecutor instance to AISimulationControlService.
- Unit Tests:
    - Updated tests for ASCS to mock SandboxExecutor and verify new interactions.
    - Updated tests for AVIS to correctly instantiate it with the new SandboxExecutor dependency for ASCS. All relevant tests pass.
- Driver Script (`examples/run_simple_coding_agent.py`):
    - Updated to instantiate and use the actual SandboxExecutor, successfully running the SimpleCodingAgent task.
- Documentation:
    - Updated ASCS README and AVIS specification to reflect the use of SandboxExecutor for Python code execution.

This change enhances the robustness, security (by using a dedicated subprocess via SandboxExecutor), and clarity of the AI code execution pipeline.