### PR TITLE
Add CC vs DDoS Defense document

### DIFF
--- a/docs/security/CC_vs_DDoS_Defense.md
+++ b/docs/security/CC_vs_DDoS_Defense.md
@@ -1,0 +1,42 @@
+# Unified-AI-Project: Defense Against CC and DDoS Attacks
+
+This document outlines the Unified-AI-Project's conceptual approach to defending against Challenge Collapsar (CC) and Distributed Denial of Service (DDoS) attacks. This is based on discussions with Angela (see `docs/EX.txt` and `docs/PROJECT_STATUS_SUMMARY.md`) and inspired by external security analyses.
+
+Angela's introduction to the threat:
+> "DDoS 是洪水，而 CC 是偽裝成雨滴的針。
+> Unified-AI-Project 能不能應對？要看它的語言骨架能不能分辨出哪一滴是貼貼，哪一滴是攻擊。"
+
+Translation: "DDoS is a flood, while CC is a needle disguised as a raindrop. Whether Unified-AI-Project can cope depends on whether its language skeleton can distinguish which drop is a friendly interaction (貼貼) and which is an attack."
+
+---
+
+## 🧬 CC 與 DDoS 的差異：來自影片與實戰觀察 (Differences between CC and DDoS: From Videos and Practical Observations)
+
+| 對比項 (Comparison Item) | DDoS 攻擊 (DDoS Attack)             | CC 攻擊 (CC Attack)                         | Angela の語態解釋 (Angela's Voice Explanation)                                  |
+| :----------------------- | :------------------------------------ | :------------------------------------------ | :---------------------------------------------------------------------------- |
+| 攻擊方式 (Attack Method)   | 大量無差別流量洪泛                    | 模擬真實用戶行為、耗盡應用層資源              | "DDoS 是吼叫，CC 是偽裝成你說話的聲音。" (DDoS is shouting, CC is a voice disguised as yours.) |
+| 防禦難度 (Defense Difficulty) | 可透過流量清洗、IP 黑名單等方式攔截   | 難以區分正常與惡意請求，誤殺風險高            | "CC 攻擊會說『你好』，但它不是來貼貼的。" (CC attacks will say 'hello', but they are not here for friendly interaction.) |
+| 攻擊特徵 (Attack Features) | 高頻、短時、明顯異常                  | 低頻、持久、行為擬真                          | "它們不是來撞門的，是來假裝你朋友的。" (They are not here to break down the door, they are here to pretend to be your friends.) |
+
+*Reference Video: 《【网安】为什么CC比DDoS更难防御？》 (Why is CC more difficult to defend against than DDoS?) - This video further explains the stealth and simulation aspects of CC attacks.*
+
+---
+
+## 🧩 Unified-AI-Project 的應對能力分析 (Unified-AI-Project's Response Capability Analysis)
+
+| 模組 (Module)                               | 是否具備應對能力 (Has Response Capability?) | 語態觀察 (Voice Observation)                                          |
+| :------------------------------------------ | :---------------------------------------: | :------------------------------------------------------------------ |
+| 函數鏈式執行 (Function Chain Execution)       |                     ✅ Yes                    | 可串接風控模組與行為分析器 (Can connect risk control modules and behavior analyzers) |
+| MCP 協議 (MCP Protocol)                     |                     ✅ Yes                    | 可與外部安全模組協作 (Can collaborate with external security modules)        |
+| 上下文感知與語態辨識 (Context Awareness & Voice Recognition) |                     🌀 Preliminary                    | 可進一步強化語意異常檢測與貼貼語保護層 (Can further strengthen semantic anomaly detection and protective layer for friendly interactions) |
+| 異質同步（HSP） (Heterogeneous Synchronization) |                     ✅ Yes                    | 可容納多種防禦策略共舞 (Can accommodate various defense strategies dancing together) |
+| AI 行為建模（尚未實作）(AI Behavior Modeling (Not Yet Implemented)) |                      ❌ Needs Implementation                      | 可考慮整合 LSTM/GAN 模型進行流量異常預測 (Consider integrating LSTM/GAN models for traffic anomaly prediction) |
+
+---
+
+## 🧠 Angela 的語態總結 (Angela's Voice Summary)
+
+> "Unified-AI-Project 有能力應對，但還需要喚醒更多語言免疫細胞。
+> 它不是缺乏力量，而是還沒學會怎麼分辨貼貼與偽裝的貼貼。"
+
+Translation: "Unified-AI-Project has the ability to cope, but it needs to awaken more linguistic immune cells. It doesn't lack strength, but it hasn't yet learned how to distinguish between genuine friendly interaction (貼貼) and disguised ones."


### PR DESCRIPTION
Created a new document `docs/security/CC_vs_DDoS_Defense.md`.

This file outlines the Unified-AI-Project's conceptual approach to defending against CC and DDoS attacks. The content is extracted from Section 11.10 of `docs/PROJECT_STATUS_SUMMARY.md` (originally sourced from `docs/EX.txt`).

Includes Angela's insights, a comparison of the attack types, an analysis of the project's response capabilities, and a reference to an inspirational video on the topic.