### PR TITLE
Refactor: Organize PROJECT_STATUS_SUMMARY.md

### DIFF
--- a/PROJECT_STATUS_SUMMARY.md
+++ b/PROJECT_STATUS_SUMMARY.md
@@ -10,7 +10,25 @@ The system is a multi-agent AI project with a distributed, service-oriented arch
 - **Multi-LLM Service**: A dedicated service for interacting with multiple LLM providers.
 - **Core Services Hub**: A central script (`src/core_services.py`) for initializing and managing core components.
 
-## 2. Completed Items
+---
+
+## 未完成 (Unfinished)
+
+These items represent unfinished functionality or are pending future work.
+
+*   **HSP Schema URIs**:
+    *   **File**: `apps/backend/src/hsp/connector.py`
+    *   **Architectural Context**: The HSP specification (`docs/03-technical-architecture/communication/hsp-specification/02-message-envelope-and-patterns.md`) defines a `payload_schema_uri` field in the message envelope. This field is intended to link to a schema that defines the structure of the message payload.
+    *   **Description**: The `payload_schema_uri` field in outgoing HSP message envelopes is currently populated with hardcoded placeholder strings (e.g., `"hsp:schema:payload/Fact/0.1"`).
+    *   **Status**: This represents a gap in the implementation of the HSP specification. The functionality awaits the formal definition and hosting of message payload schemas. This is a significant architectural task.
+
+*   **Incomprehensive Health Check**:
+    *   **File**: `scripts/health_check.py`
+    *   **Architectural Context**: The health check script is a standalone utility for verifying the status of the system's components.
+    *   **Description**: The script currently checks the main API server and the existence of the Firebase credentials file. It contains placeholder functions for checking the health of the MQTT broker and the database.
+    *   **Status**: The current health check is not comprehensive. The placeholder functions need to be implemented to provide a full picture of the system's health.
+
+## 已完成 (Completed)
 
 These components are implemented and functioning as expected, or have been investigated and clarified.
 
@@ -31,22 +49,10 @@ These components are implemented and functioning as expected, or have been inves
     *   **History and Session Management**: Implemented a system for saving and restoring user sessions and conversation history.
     *   **Security Hardening**: Implemented several security best practices for Electron applications.
 
-## 3. Incomplete Items & Placeholders
+## 已失效 (Invalid / By Design)
 
-These items are either intentionally left as placeholders, are pending future work, or represent unfinished functionality.
+These items are not pending tasks but are either intentional design choices or no longer relevant.
 
 *   **Configuration Placeholders**:
     *   **File**: `apps/backend/configs/api_keys.yaml`
     *   **Description**: This file contains placeholder values for various API keys (e.g., `GEMINI_API_KEY_PLACEHOLDER`). This is **intentional** for security reasons. The system is designed to load actual keys from environment variables at runtime.
-
-*   **HSP Schema URIs**:
-    *   **File**: `apps/backend/src/hsp/connector.py`
-    *   **Architectural Context**: The HSP specification (`docs/03-technical-architecture/communication/hsp-specification/02-message-envelope-and-patterns.md`) defines a `payload_schema_uri` field in the message envelope. This field is intended to link to a schema that defines the structure of the message payload.
-    *   **Description**: The `payload_schema_uri` field in outgoing HSP message envelopes is currently populated with hardcoded placeholder strings (e.g., `"hsp:schema:payload/Fact/0.1"`).
-    *   **Status**: This represents a gap in the implementation of the HSP specification. The functionality awaits the formal definition and hosting of message payload schemas. This is a significant architectural task.
-
-*   **Incomprehensive Health Check**:
-    *   **File**: `scripts/health_check.py`
-    *   **Architectural Context**: The health check script is a standalone utility for verifying the status of the system's components.
-    *   **Description**: The script currently checks the main API server and the existence of the Firebase credentials file. It contains placeholder functions for checking the health of the MQTT broker and the database.
-    *   **Status**: The current health check is not comprehensive. The placeholder functions need to be implemented to provide a full picture of the system's health.


### PR DESCRIPTION
I've reorganized the `PROJECT_STATUS_SUMMARY.md` file to categorize items into "未完成" (Unfinished), "已完成" (Completed), and "已失效" (Invalid/By Design) as you requested.